### PR TITLE
ENG-3978 Adjusting custom statistics for unplanned stops and unplanned plan units

### DIFF
--- a/factory/format.go
+++ b/factory/format.go
@@ -286,14 +286,20 @@ func DefaultCustomResultStatistics(solution nextroute.Solution) schema.CustomRes
 		}
 	}
 
+	unplannedStops := common.MapSlice(
+		solution.UnPlannedPlanUnits().SolutionPlanUnits(),
+		toSolutionOutputStops,
+	)
+
 	return schema.CustomResultStatistics{
-		ActivatedVehicles: vehicleCount,
-		UnplannedStops:    solution.UnPlannedPlanUnits().Size(),
-		MaxTravelDuration: maxTravelDuration,
-		MaxDuration:       maxDuration,
-		MinTravelDuration: minTravelDuration,
-		MinDuration:       minDuration,
-		MaxStopsInVehicle: maxStops,
-		MinStopsInVehicle: minStops,
+		ActivatedVehicles:  vehicleCount,
+		UnplannedPlanUnits: solution.UnPlannedPlanUnits().Size(),
+		UnplannedStops:     len(unplannedStops),
+		MaxTravelDuration:  maxTravelDuration,
+		MaxDuration:        maxDuration,
+		MinTravelDuration:  minTravelDuration,
+		MinDuration:        minDuration,
+		MaxStopsInVehicle:  maxStops,
+		MinStopsInVehicle:  minStops,
 	}
 }

--- a/factory/format.go
+++ b/factory/format.go
@@ -292,14 +292,13 @@ func DefaultCustomResultStatistics(solution nextroute.Solution) schema.CustomRes
 	)
 
 	return schema.CustomResultStatistics{
-		ActivatedVehicles:  vehicleCount,
-		UnplannedPlanUnits: solution.UnPlannedPlanUnits().Size(),
-		UnplannedStops:     len(unplannedStops),
-		MaxTravelDuration:  maxTravelDuration,
-		MaxDuration:        maxDuration,
-		MinTravelDuration:  minTravelDuration,
-		MinDuration:        minDuration,
-		MaxStopsInVehicle:  maxStops,
-		MinStopsInVehicle:  minStops,
+		ActivatedVehicles: vehicleCount,
+		UnplannedStops:    len(unplannedStops),
+		MaxTravelDuration: maxTravelDuration,
+		MaxDuration:       maxDuration,
+		MinTravelDuration: minTravelDuration,
+		MinDuration:       minDuration,
+		MaxStopsInVehicle: maxStops,
+		MinStopsInVehicle: minStops,
 	}
 }

--- a/schema/output.go
+++ b/schema/output.go
@@ -111,6 +111,10 @@ type CustomResultStatistics struct {
 	// UnplannedStops is the number of stops that were not planned in the
 	// solution.
 	UnplannedStops int `json:"unplanned_stops"`
+	// UnplannedPlanUnits is the number of plan units that were not planned in the
+	// solution. A plan unit can consist of multiple stops. e.g. a pickup and
+	// dropoff stop.
+	UnplannedPlanUnits int `json:"unplanned_units"`
 	// MaxTravelDuration is the maximum travel duration of a vehicle in the
 	// solution.
 	MaxTravelDuration int `json:"max_travel_duration"`

--- a/schema/output.go
+++ b/schema/output.go
@@ -111,10 +111,6 @@ type CustomResultStatistics struct {
 	// UnplannedStops is the number of stops that were not planned in the
 	// solution.
 	UnplannedStops int `json:"unplanned_stops"`
-	// UnplannedPlanUnits is the number of plan units that were not planned in the
-	// solution. A plan unit can consist of multiple stops. e.g. a pickup and
-	// dropoff stop.
-	UnplannedPlanUnits int `json:"unplanned_units"`
 	// MaxTravelDuration is the maximum travel duration of a vehicle in the
 	// solution.
 	MaxTravelDuration int `json:"max_travel_duration"`

--- a/tests/golden/testdata/alternates.json.golden
+++ b/tests/golden/testdata/alternates.json.golden
@@ -261,7 +261,7 @@
         "min_duration": 11,
         "min_stops_in_vehicle": 2,
         "min_travel_duration": 11,
-        "unplanned_stops": 2
+        "unplanned_stops": 0
       },
       "duration": 0.123,
       "value": 4000925.1454996876

--- a/tests/golden/testdata/initial_stops_infeasible_tuple.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_tuple.json.golden
@@ -173,7 +173,7 @@
         "min_duration": 620,
         "min_stops_in_vehicle": 1,
         "min_travel_duration": 20,
-        "unplanned_stops": 2
+        "unplanned_stops": 4
       },
       "duration": 0.123,
       "value": 80620.0061571598

--- a/tests/golden/testdata/template_input.json.golden
+++ b/tests/golden/testdata/template_input.json.golden
@@ -610,7 +610,7 @@
         "min_duration": 14135,
         "min_stops_in_vehicle": 9,
         "min_travel_duration": 11435,
-        "unplanned_stops": 3
+        "unplanned_stops": 7
       },
       "duration": 0.123,
       "value": 2059665.4384450912


### PR DESCRIPTION
This PR adds a differentation of unplanned stops and unplanned plan units to the custom statistics section to avoid confusion between the length of the list of unplanned stops and the previously displayed number of unplanned stops.

The custom statistics section now displays both values:

```json
"unplanned_stops": 6,
"unplanned_units": 4,
``` 