### PR TITLE
ENG-3202 Add a conversion function for schema.Location to measure.Point

### DIFF
--- a/schema/input.go
+++ b/schema/input.go
@@ -5,6 +5,8 @@ package schema
 
 import (
 	"time"
+
+	"github.com/nextmv-io/sdk/measure"
 )
 
 // Input is the default input schema for nextroute.
@@ -224,6 +226,11 @@ type Location struct {
 	Lon float64 `json:"lon" minimum:"-180" maximum:"180"`
 	// Lat latitude of the location.
 	Lat float64 `json:"lat" minimum:"-90" maximum:"90"`
+}
+
+// ToPoint converts a schema.Location to a measure.Point.
+func (l Location) ToPoint() measure.Point {
+	return measure.Point{l.Lon, l.Lat}
 }
 
 // DurationGroup represents a group of stops that get additional duration


### PR DESCRIPTION
This was internally requested with [this ticket](https://linear.app/nextmv/issue/ENG-3202/provide-a-convenient-conversion-from-nextroutelocation-to-measurepoint). It adds a conversion function that let's you easily convert from a schema.Location to a measure.Point.

Let me know if I should move to another place. 