### PR TITLE
Add benchmark tests based on golden files

### DIFF
--- a/tests/golden/benchmark_test.go
+++ b/tests/golden/benchmark_test.go
@@ -1,0 +1,71 @@
+// © 2019-present nextmv.io inc
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nextmv-io/nextroute"
+	"github.com/nextmv-io/nextroute/factory"
+	"github.com/nextmv-io/nextroute/schema"
+	"github.com/nextmv-io/sdk/run"
+)
+
+func BenchmarkGolden(b *testing.B) {
+	benchmarkFiles := []string{}
+	files, err := os.ReadDir("testdata")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(file.Name(), ".json") {
+			benchmarkFiles = append(benchmarkFiles, "testdata/"+file.Name())
+		}
+	}
+	ctx := context.Background()
+	solveOptions := nextroute.ParallelSolveOptions{
+		Iterations:           50,
+		Duration:             10 * time.Second,
+		ParallelRuns:         1,
+		StartSolutions:       1,
+		RunDeterministically: true,
+	}
+	for _, file := range benchmarkFiles {
+		b.Run(file, func(b *testing.B) {
+			var input schema.Input
+			data, err := os.ReadFile(file)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := json.Unmarshal(data, &input); err != nil {
+				b.Fatal(err)
+			}
+			model, err := factory.NewModel(input, factory.Options{})
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				solver, err := nextroute.NewParallelSolver(model)
+				if err != nil {
+					b.Fatal(err)
+				}
+				ctx = context.WithValue(ctx, run.Start, time.Now())
+				b.StartTimer()
+				_, err = solver.Solve(ctx, solveOptions)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/tests/golden/main_test.go
+++ b/tests/golden/main_test.go
@@ -50,6 +50,7 @@ func cleanUp() {
 	keep := []string{
 		"testdata",
 		"main_test.go",
+		"benchmark_test.go",
 	}
 	golden.Reset(keep)
 }


### PR DESCRIPTION
This adds a set of benchmark tests for all golden files. This allows us to quickly run some benchmarks that cover quite a bit of code. Of course that does not replace running longer on bigger instances, but it's a nice middle ground I hope.

to run them

```bash
go test -benchmem -run=^$ -count 10 -bench ^Benchmark ./... > old.txt
# make changes to code
go test -benchmem -run=^$ -count 10 -bench ^Benchmark ./... > new.txt 
benchstat old.txt new.txt
```