### PR TITLE
Improves value function performance

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -283,6 +283,10 @@ issues:
     - path: model\.go
       linters:
         - lll
+    # Deactivate gocyclo in model.go for lock func.
+    - path: model\.go
+      linters:
+        - gocyclo
     # Deactivate line length in factory/model.go because of go tags
     - path: factory/model\.go
       linters:

--- a/factory/format.go
+++ b/factory/format.go
@@ -146,7 +146,9 @@ func toPlannedStopOutput(solutionStop nextroute.SolutionStop) schema.PlannedStop
 		}
 	}
 
-	if data, ok := solutionStop.Vehicle().ModelVehicle().VehicleType().Data().(vehicleTypeData); ok {
+	hasTravelDistance := solutionStop.Previous().ModelStop().Location().IsValid() &&
+		solutionStop.ModelStop().Location().IsValid()
+	if data, ok := solutionStop.Vehicle().ModelVehicle().VehicleType().Data().(vehicleTypeData); ok && hasTravelDistance {
 		distance := data.DistanceExpression.Value(
 			solutionStop.Vehicle().ModelVehicle().VehicleType(),
 			solutionStop.Previous().ModelStop(),

--- a/model_constraint_successors.go
+++ b/model_constraint_successors.go
@@ -29,6 +29,13 @@ type successorConstraintImpl struct {
 
 func (l *successorConstraintImpl) Lock(model Model) error {
 	modelImpl := model.(*modelImpl)
+
+	// initialize disallowedSuccessors
+	modelImpl.disallowedSuccessors = make([][]bool, modelImpl.NumberOfStops())
+	for i := range modelImpl.disallowedSuccessors {
+		modelImpl.disallowedSuccessors[i] = make([]bool, modelImpl.NumberOfStops())
+	}
+
 	// copy the information from disallowedSuccessors to the model
 	for stop, successors := range l.disallowedSuccessors {
 		for _, successor := range successors {

--- a/model_directed_acyclic_graph.go
+++ b/model_directed_acyclic_graph.go
@@ -144,8 +144,12 @@ func (d *directedAcyclicGraphImpl) AddArc(origin, destination ModelStop) error {
 }
 
 func (d *directedAcyclicGraphImpl) HasDirectArc(origin, destination ModelStop) bool {
-	if arc, ok := d.outboundDirectArcs[origin.Index()]; ok {
-		return arc.Destination().Index() == destination.Index()
+	return d.hasDirectArc(origin.Index(), destination.Index())
+}
+
+func (d *directedAcyclicGraphImpl) hasDirectArc(originIndex, destinationIndex int) bool {
+	if arc, ok := d.outboundDirectArcs[originIndex]; ok {
+		return arc.Destination().Index() == destinationIndex
 	}
 	return false
 }

--- a/model_expression_haversine.go
+++ b/model_expression_haversine.go
@@ -59,9 +59,8 @@ func (h *haversineExpression) Value(
 	from ModelStop,
 	to ModelStop,
 ) float64 {
-	if from == nil || to == nil || !from.Location().IsValid() || !to.Location().IsValid() {
-		return 0.0
-	}
-	return haversineDistance(from.Location(), to.Location()).
-		Value(vehicle.Model().DistanceUnit())
+	return haversineDistance(
+		from.Location(),
+		to.Location(),
+	).Value(vehicle.Model().DistanceUnit())
 }

--- a/model_expression_measure_byindex.go
+++ b/model_expression_measure_byindex.go
@@ -52,8 +52,8 @@ func (m *measureByIndexExpression) SetName(n string) {
 }
 
 func (m *measureByIndexExpression) Value(_ ModelVehicleType, from, to ModelStop) float64 {
-	if from == nil || to == nil || !from.Location().IsValid() || !to.Location().IsValid() {
-		return 0.0
-	}
-	return m.measure.Cost(from.(*stopImpl).measureIndex, to.(*stopImpl).measureIndex)
+	return m.measure.Cost(
+		from.(*stopImpl).measureIndex,
+		to.(*stopImpl).measureIndex,
+	)
 }

--- a/model_expression_measure_bypoint.go
+++ b/model_expression_measure_bypoint.go
@@ -52,14 +52,7 @@ func (m *measureByPointExpression) SetName(n string) {
 }
 
 func (m *measureByPointExpression) Value(_ ModelVehicleType, from, to ModelStop) float64 {
-	if from == nil || to == nil {
-		return 0.0
-	}
-	locFrom := from.Location()
-	locTo := to.Location()
-	if !locFrom.IsValid() || !locTo.IsValid() {
-		return 0.0
-	}
+	locFrom, locTo := from.Location(), to.Location()
 	value := m.measure.Cost(
 		measure.Point{locFrom.Longitude(), locFrom.Latitude()},
 		measure.Point{locTo.Longitude(), locTo.Latitude()},

--- a/solution_move_stops_generator.go
+++ b/solution_move_stops_generator.go
@@ -126,7 +126,8 @@ func SolutionMoveStopsGenerator(
 	locations := make([]int, 0, len(source))
 
 	model := vehicle.solution.model.(*modelImpl)
-	if model.hasDisallowedSuccessors() || model.hasDirectSuccessors {
+	_ = model
+	if true {
 		generate(positions, locations, source, target, func() {
 			m.(*solutionMoveStopsImpl).reset()
 			m.(*solutionMoveStopsImpl).planUnit = planUnit

--- a/solution_move_stops_generator.go
+++ b/solution_move_stops_generator.go
@@ -126,8 +126,7 @@ func SolutionMoveStopsGenerator(
 	locations := make([]int, 0, len(source))
 
 	model := vehicle.solution.model.(*modelImpl)
-	_ = model
-	if true {
+	if model.hasDisallowedSuccessors() || model.hasDirectSuccessors {
 		generate(positions, locations, source, target, func() {
 			m.(*solutionMoveStopsImpl).reset()
 			m.(*solutionMoveStopsImpl).planUnit = planUnit

--- a/solution_move_stops_generator.go
+++ b/solution_move_stops_generator.go
@@ -138,20 +138,22 @@ func SolutionMoveStopsGenerator(
 func isNotAllowed(from, to solutionStopImpl) bool {
 	fromModelStop := from.modelStop()
 	toModelStop := to.modelStop()
-	model := fromModelStop.Model()
+	model := fromModelStop.model
 
-	return model.(*modelImpl).disallowedSuccessors[fromModelStop.Index()][toModelStop.Index()]
+	return model.disallowedSuccessors[fromModelStop.index][toModelStop.index]
 }
 
 func mustBeNeighbours(from, to solutionStopImpl) bool {
-	if !from.modelStop().HasPlanStopsUnit() {
+	fromModelStop := from.modelStop()
+	if !fromModelStop.HasPlanStopsUnit() {
 		return false
 	}
+	toModelStop := to.modelStop()
 
-	return from.modelStop().
-		PlanStopsUnit().
-		DirectedAcyclicGraph().
-		HasDirectArc(from.ModelStop(), to.ModelStop())
+	return fromModelStop.
+		planUnit.(*planMultipleStopsImpl).
+		dag.(*directedAcyclicGraphImpl).
+		hasDirectArc(fromModelStop.index, toModelStop.index)
 }
 
 func generate(

--- a/solution_move_stops_generator.go
+++ b/solution_move_stops_generator.go
@@ -125,35 +125,59 @@ func SolutionMoveStopsGenerator(
 
 	locations := make([]int, 0, len(source))
 
-	generate(positions, locations, source, target, func() {
-		m.(*solutionMoveStopsImpl).reset()
-		m.(*solutionMoveStopsImpl).planUnit = planUnit
-		m.(*solutionMoveStopsImpl).stopPositions = positions
-		m.(*solutionMoveStopsImpl).allowed = false
-		m.(*solutionMoveStopsImpl).valueSeen = 1
-		yield(m)
-	}, shouldStop)
+	model := vehicle.solution.model.(*modelImpl)
+	if model.hasDisallowedSuccessors() || model.hasDirectSuccessors {
+		generate(positions, locations, source, target, func() {
+			m.(*solutionMoveStopsImpl).reset()
+			m.(*solutionMoveStopsImpl).planUnit = planUnit
+			m.(*solutionMoveStopsImpl).stopPositions = positions
+			m.(*solutionMoveStopsImpl).allowed = false
+			m.(*solutionMoveStopsImpl).valueSeen = 1
+			yield(m)
+		}, shouldStop)
+	} else {
+		combineAscending(locations, len(source), len(target)-1, func(locations []int) {
+			for idx, location := range locations {
+				positions[idx].previousStopIndex = target[location-1].index
+				positions[idx].nextStopIndex = target[location].index
+				if idx > 0 && locations[idx-1] == location {
+					positions[idx].previousStopIndex = source[idx-1].index
+				}
+				if idx < len(locations)-1 && locations[idx+1] == location {
+					positions[idx].nextStopIndex = source[idx+1].index
+				}
+			}
+			m.(*solutionMoveStopsImpl).reset()
+			m.(*solutionMoveStopsImpl).planUnit = planUnit
+			m.(*solutionMoveStopsImpl).stopPositions = positions
+			m.(*solutionMoveStopsImpl).allowed = false
+			m.(*solutionMoveStopsImpl).valueSeen = 1
+			yield(m)
+		}, shouldStop)
+	}
 }
 
-func isNotAllowed(from, to solutionStopImpl) bool {
-	fromModelStop := from.modelStop()
-	toModelStop := to.modelStop()
-	model := fromModelStop.model
-
-	return model.disallowedSuccessors[fromModelStop.index][toModelStop.index]
+func isNotAllowed(model *modelImpl, from, to solutionStopImpl) bool {
+	if !model.hasDisallowedSuccessors() {
+		return false
+	}
+	return model.disallowedSuccessors[from.ModelStopIndex()][to.ModelStopIndex()]
 }
 
-func mustBeNeighbours(from, to solutionStopImpl) bool {
+func mustBeNeighbours(model *modelImpl, from, to solutionStopImpl) bool {
+	if !model.hasDirectSuccessors {
+		return false
+	}
+
 	fromModelStop := from.modelStop()
 	if !fromModelStop.HasPlanStopsUnit() {
 		return false
 	}
-	toModelStop := to.modelStop()
 
 	return fromModelStop.
 		planUnit.(*planMultipleStopsImpl).
 		dag.(*directedAcyclicGraphImpl).
-		hasDirectArc(fromModelStop.index, toModelStop.index)
+		hasDirectArc(fromModelStop.index, to.ModelStopIndex())
 }
 
 func generate(
@@ -178,8 +202,10 @@ func generate(
 		start = combination[len(combination)-1] - 1
 	}
 
+	model := target[0].modelStop().model
+
 	for i := start; i < len(target)-1; i++ {
-		if i > 0 && mustBeNeighbours(target[i], target[i+1]) {
+		if i > 0 && mustBeNeighbours(model, target[i], target[i+1]) {
 			continue
 		}
 		combination = append(combination, i+1)
@@ -195,12 +221,12 @@ func generate(
 				stopPositions[positionIdx-1].nextStopIndex = stopPositions[positionIdx].stopIndex
 			} else {
 				stopPositions[positionIdx-1].nextStopIndex = target[combination[positionIdx-1]].index
-				if mustBeNeighbours(stopPositions[positionIdx-1].stop(), stopPositions[positionIdx].stop()) {
+				if mustBeNeighbours(model, stopPositions[positionIdx-1].stop(), stopPositions[positionIdx].stop()) {
 					break
 				}
 			}
 
-			if isNotAllowed(stopPositions[positionIdx-1].stop(), stopPositions[positionIdx-1].next()) {
+			if isNotAllowed(model, stopPositions[positionIdx-1].stop(), stopPositions[positionIdx-1].next()) {
 				combination = combination[:positionIdx]
 				if stopPositions[positionIdx-1].nextStopIndex != stopPositions[positionIdx].previousStopIndex {
 					break
@@ -209,13 +235,48 @@ func generate(
 			}
 		}
 
-		if isNotAllowed(stopPositions[positionIdx].previous(), stopPositions[positionIdx].stop()) {
+		if isNotAllowed(model, stopPositions[positionIdx].previous(), stopPositions[positionIdx].stop()) {
 			combination = combination[:positionIdx]
 			continue
 		}
 
 		generate(stopPositions, combination, source, target, yield, shouldStop)
 
+		combination = combination[:len(combination)-1]
+	}
+}
+
+// combineAscending generates all combinations of n elements from m where
+// the elements are in ascending order.
+// 2,3 (2 elements can be at 3 locations) will generate:
+// [1 1] first at first location, second at first location
+// [1 2] first at first location, second at second location
+// [1 3] first at first location, second at third location
+// [2 2] first at second location, second at second location
+// [2 3] first at second location, second at third location
+// [3 3] first at third location, second at third location
+// 3, 2 (3 elements can be at 2 locations) will generate:
+// [1 1 1] first at first location, second at first location, third at first location
+// [1 1 2] first at first location, second at first location, third at second location
+// [1 2 2] first at first location, second at second location, third at second location
+// [2 2 2] first at second location, second at second location, third at second location
+// Being at the same location means element are next to each other.
+// The function yield is called for each combination of size n.
+func combineAscending(combination []int, n int, m int, yield func([]int), shouldStop func() bool) {
+	if shouldStop() {
+		return
+	}
+	if len(combination) == n {
+		yield(combination)
+		return
+	}
+	start := 0
+	if len(combination) > 0 {
+		start = combination[len(combination)-1] - 1
+	}
+	for i := start; i < m; i++ {
+		combination = append(combination, i+1)
+		combineAscending(combination, n, m, yield, shouldStop)
 		combination = combination[:len(combination)-1]
 	}
 }


### PR DESCRIPTION
# Description
Fixes a performance regression that surfaces under particular circumstances that was caused by extra checks in the value function and the new (more generic) stop generation logic.

# Changes
- Added a check for travel distance validity before accessing value function in `factory/format.go`.
- Simplified value functions.
- Avoids some interfaces in stop generation.
- Uses old (faster) logic when no forced neighbors or "disallowed" successors exist.
- Improved new logic by accessing info more directly and avoiding some funcs if possible.