### PR TITLE
Make location a struct

### DIFF
--- a/common/location.go
+++ b/common/location.go
@@ -4,31 +4,32 @@ package common
 
 import (
 	"fmt"
+	"math"
 )
 
 // NewLocation creates a new Location. An error is returned if the longitude is
 // not between (-180, 180) or the latitude is not between (-90, 90).
 func NewLocation(longitude float64, latitude float64) (Location, error) {
-	if longitude < -180 || longitude > 180 {
+	if !isValidLongitude(longitude) {
 		return NewInvalidLocation(),
 			fmt.Errorf("longitude %f must be between -180 and 180", longitude)
 	}
-	if latitude < -90 || latitude > 90 {
+	if !isValidLatitude(latitude) {
 		return NewInvalidLocation(),
 			fmt.Errorf("latitude %f must be between -90 and 90", latitude)
 	}
-	return location{
+	return Location{
 		longitude: longitude,
 		latitude:  latitude,
-		valid:     true,
 	}, nil
 }
 
 // NewInvalidLocation creates a new invalid Location. Longitude and latitude
 // are not important.
 func NewInvalidLocation() Location {
-	return location{
-		valid: false,
+	return Location{
+		longitude: math.NaN(),
+		latitude:  math.NaN(),
 	}
 }
 
@@ -37,15 +38,15 @@ type Locations []Location
 
 // Unique returns a new slice of Locations with unique locations.
 func (l Locations) Unique() Locations {
-	unique := make(map[string]Location)
+	unique := make(map[Location]struct{}, len(l))
 	for _, location := range l {
-		// TODO: in Go 1.20 we don't need to use fmt.Sprintf here.
-		// This can simply become unique[location] = struct{}{}
-		unique[fmt.Sprintf("%v", location)] = location
+		unique[location] = struct{}{}
 	}
-	result := make(Locations, 0, len(unique))
-	for _, location := range unique {
-		result = append(result, location)
+	result := make(Locations, len(unique))
+	i := 0
+	for location := range unique {
+		result[i] = location
+		i++
 	}
 	return result
 }
@@ -58,44 +59,28 @@ func (l Locations) Centroid() (Location, error) {
 	}
 	lat := 0.0
 	lon := 0.0
-	for l, location := range l {
-		if !location.IsValid() {
-			return NewInvalidLocation(),
-				fmt.Errorf(
-					"location %d (%f, %f) is invalid",
-					l,
-					location.Longitude(),
-					location.Latitude(),
-				)
-		}
+	for _, location := range l {
+		// invalid locations are encoded as NaN, which will propagate
+		// so we can avoid a check here.
 		lat += location.Latitude()
 		lon += location.Longitude()
 	}
-	return NewLocation(lon/float64(len(l)), lat/float64(len(l)))
+	n := float64(len(l))
+	loc, err := NewLocation(lon/n, lat/n)
+	if err != nil {
+		return NewInvalidLocation(), err
+	}
+	return loc, nil
 }
 
-// Location represents a physical location on the earth.
-type Location interface {
-	// Longitude returns the longitude of the location.
-	Longitude() float64
-	// Latitude returns the latitude of the location.
-	Latitude() float64
-	// Equals returns true if the location is equal to the location given as an
-	// argument.
-	Equals(Location) bool
-	// IsValid returns true if the location is valid. A location is valid if
-	// the bounds of the longitude and latitude are correct.
-	IsValid() bool
-}
-
-// Implements Location.
-type location struct {
+// Location represents a location on earth.
+type Location struct {
 	longitude float64
 	latitude  float64
-	valid     bool
 }
 
-func (l location) String() string {
+// String returns a string representation of the location.
+func (l Location) String() string {
 	return fmt.Sprintf(
 		"{lat: %v,lon: %v}",
 		l.latitude,
@@ -103,18 +88,31 @@ func (l location) String() string {
 	)
 }
 
-func (l location) Longitude() float64 {
+// Longitude returns the longitude of the location.
+func (l Location) Longitude() float64 {
 	return l.longitude
 }
 
-func (l location) Latitude() float64 {
+// Latitude returns the latitude of the location.
+func (l Location) Latitude() float64 {
 	return l.latitude
 }
 
-func (l location) Equals(other Location) bool {
+// Equals returns true if the invoking location is equal to the other location.
+func (l Location) Equals(other Location) bool {
 	return l.longitude == other.Longitude() && l.latitude == other.Latitude()
 }
 
-func (l location) IsValid() bool {
-	return l.valid
+// IsValid returns true if the location is valid. A location is valid if the
+// longitude is between (-180, 180) and the latitude is between (-90, 90).
+func (l Location) IsValid() bool {
+	return isValidLongitude(l.longitude) && isValidLatitude(l.latitude)
+}
+
+func isValidLongitude(longitude float64) bool {
+	return longitude >= -180 && longitude <= 180
+}
+
+func isValidLatitude(latitude float64) bool {
+	return latitude >= -90 && latitude <= 90
 }

--- a/common/location.go
+++ b/common/location.go
@@ -103,8 +103,8 @@ func (l Location) Equals(other Location) bool {
 	return l.longitude == other.Longitude() && l.latitude == other.Latitude()
 }
 
-// IsValid returns true if the location is valid. A location is valid if the
-// longitude is between (-180, 180) and the latitude is between (-90, 90).
+// IsValid returns true if the location is valid. A location is valid if
+// the bounds of the longitude and latitude are correct.
 func (l Location) IsValid() bool {
 	return isValidLongitude(l.longitude) && isValidLatitude(l.latitude)
 }

--- a/common/location.go
+++ b/common/location.go
@@ -21,6 +21,7 @@ func NewLocation(longitude float64, latitude float64) (Location, error) {
 	return Location{
 		longitude: longitude,
 		latitude:  latitude,
+		valid:     true,
 	}, nil
 }
 
@@ -30,6 +31,7 @@ func NewInvalidLocation() Location {
 	return Location{
 		longitude: math.NaN(),
 		latitude:  math.NaN(),
+		valid:     false,
 	}
 }
 
@@ -77,6 +79,7 @@ func (l Locations) Centroid() (Location, error) {
 type Location struct {
 	longitude float64
 	latitude  float64
+	valid     bool
 }
 
 // String returns a string representation of the location.
@@ -106,7 +109,7 @@ func (l Location) Equals(other Location) bool {
 // IsValid returns true if the location is valid. A location is valid if
 // the bounds of the longitude and latitude are correct.
 func (l Location) IsValid() bool {
-	return isValidLongitude(l.longitude) && isValidLatitude(l.latitude)
+	return l.valid
 }
 
 func isValidLongitude(longitude float64) bool {

--- a/common/location_test.go
+++ b/common/location_test.go
@@ -1,0 +1,81 @@
+// © 2019-present nextmv.io inc
+
+package common_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/nextmv-io/nextroute/common"
+)
+
+func BenchmarkLocation(b *testing.B) {
+	r := rand.New(rand.NewSource(0))
+	lon, lat := r.Float64()*360-180, r.Float64()*180-90
+	l, _ := common.NewLocation(lon, lat)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = l.IsValid()
+	}
+}
+
+func BenchmarkUnique(b *testing.B) {
+	// test for different number of locations
+	for _, n := range []int{10, 100, 1_000, 10_000} {
+		locations := make(common.Locations, 0, n)
+		r := rand.New(rand.NewSource(0))
+		for i := 0; i < n; i++ {
+			l, _ := common.NewLocation(r.Float64()*360-180, r.Float64()*180-90)
+			if !l.IsValid() {
+				b.Error("invalid location")
+			}
+			locations = append(locations, l)
+		}
+		b.Run(fmt.Sprintf("n=%v", n), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = locations.Unique()
+			}
+		})
+	}
+}
+
+func TestUnique(t *testing.T) {
+	newLocation := func(lon, lat float64) common.Location {
+		l, err := common.NewLocation(lon, lat)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return l
+	}
+	locations := common.Locations{
+		newLocation(0, 0),
+		newLocation(123.234983434, 80.234983434),
+		newLocation(123.234983434, 80.234983434),
+		newLocation(0, 0),
+		newLocation(0, 0),
+		newLocation(0, 0),
+		newLocation(0, 0),
+	}
+	unique := locations.Unique()
+	if len(unique) != 2 {
+		t.Errorf("expected 2 unique locations, got %v", len(unique))
+	}
+}
+
+func BenchmarkCentroid(b *testing.B) {
+	locations := make(common.Locations, 0, 2_000)
+	r := rand.New(rand.NewSource(0))
+	for i := 0; i < 2_000; i++ {
+		l, _ := common.NewLocation(r.Float64()*360-180, r.Float64()*180-90)
+		if !l.IsValid() {
+			b.Error("invalid location")
+		}
+		locations = append(locations, l)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = locations.Centroid()
+	}
+}

--- a/common/location_test.go
+++ b/common/location_test.go
@@ -41,6 +41,20 @@ func BenchmarkUnique(b *testing.B) {
 	}
 }
 
+func TestLocation(t *testing.T) {
+	l, err := common.NewLocation(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !l.IsValid() {
+		t.Error("expected valid location")
+	}
+	invalid := common.NewInvalidLocation()
+	if invalid.IsValid() {
+		t.Error("expected invalid location")
+	}
+}
+
 func TestUnique(t *testing.T) {
 	newLocation := func(lon, lat float64) common.Location {
 		l, err := common.NewLocation(lon, lat)

--- a/common/location_test.go
+++ b/common/location_test.go
@@ -53,6 +53,13 @@ func TestLocation(t *testing.T) {
 	if invalid.IsValid() {
 		t.Error("expected invalid location")
 	}
+	l, err = common.NewLocation(180.1, 0)
+	if err == nil {
+		t.Error("expected error")
+	}
+	if l.IsValid() {
+		t.Error("expected invalid location")
+	}
 }
 
 func TestUnique(t *testing.T) {

--- a/solution_construcation_sweep_test.go
+++ b/solution_construcation_sweep_test.go
@@ -32,8 +32,8 @@ func TestSweepTwoDepots(t *testing.T) {
 	input := singleVehiclePlanSingleStopsModel()
 
 	location := Location{
-		Lat: common.NewInvalidLocation().Latitude(),
-		Lon: common.NewInvalidLocation().Longitude(),
+		Lat: 0,
+		Lon: 0,
 	}
 	input.Vehicles = append(input.Vehicles, vehicles("truck", location, 1)...)
 	model, err := createModel(input)

--- a/tests/golden/benchmark_test.go
+++ b/tests/golden/benchmark_test.go
@@ -47,13 +47,13 @@ func BenchmarkGolden(b *testing.B) {
 			if err := json.Unmarshal(data, &input); err != nil {
 				b.Fatal(err)
 			}
+			model, err := factory.NewModel(input, factory.Options{})
+			if err != nil {
+				b.Fatal(err)
+			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				model, err := factory.NewModel(input, factory.Options{})
-				if err != nil {
-					b.Fatal(err)
-				}
 				solver, err := nextroute.NewParallelSolver(model)
 				if err != nil {
 					b.Fatal(err)


### PR DESCRIPTION
This improves efficiency by making the location a struct and also reduce its size (8 fewer bytes). This has likely some effect on the whole search as we consume fewer bytes on an object that gets copied billions of time which decreases the time it takes to check for a valid location (among other things).

The main changes are:
* Make the location a struct to avoid `convT` allocation unexpectedly somewhere
* Reduce the size by encoding an invalid location as `NaN` in the `float64` fields.

This PR also improves the performance of `Unique` and `Centroid`

Benchmarks (only for checking if a location is valid):
```
name              old time/op    new time/op    delta
Location-8          2.07ns ± 0%    0.79ns ± 0%   -61.72%  (p=0.000 n=9+10)
Unique/n=10-8       3.83µs ± 0%    0.49µs ± 1%   -87.13%  (p=0.000 n=9+10)
Unique/n=100-8      40.3µs ± 0%     4.9µs ± 1%   -87.92%  (p=0.000 n=8+9)
Unique/n=1000-8      418µs ± 0%      47µs ± 3%   -88.79%  (p=0.000 n=10+9)
Unique/n=10000-8    4.28ms ± 0%    0.47ms ± 2%   -89.13%  (p=0.000 n=9+8)
Centroid-8          11.1µs ± 1%     1.9µs ± 0%   -83.25%  (p=0.000 n=10+9)

name              old alloc/op   new alloc/op   delta
Location-8           0.00B          0.00B           ~     (all equal)
Unique/n=10-8       1.99kB ± 0%    0.50kB ± 0%   -74.94%  (p=0.000 n=9+10)
Unique/n=100-8      25.0kB ± 0%     4.7kB ± 0%   -81.22%  (p=0.000 n=10+10)
Unique/n=1000-8      313kB ± 0%      57kB ± 0%   -81.62%  (p=0.000 n=10+10)
Unique/n=10000-8    2.74MB ± 0%    0.49MB ± 0%   -82.28%  (p=0.000 n=9+10)
Centroid-8           24.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)

name              old allocs/op  new allocs/op  delta
Location-8            0.00           0.00           ~     (all equal)
Unique/n=10-8         42.0 ± 0%       4.0 ± 0%   -90.48%  (p=0.000 n=10+10)
Unique/n=100-8         410 ± 0%         7 ± 0%   -98.29%  (p=0.000 n=10+10)
Unique/n=1000-8      4.03k ± 0%     0.01k ± 0%   -99.83%  (p=0.000 n=10+10)
Unique/n=10000-8     40.2k ± 0%      0.0k ± 0%   -99.97%  (p=0.000 n=10+10)
Centroid-8            1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

In addition most operations on locations can now be inlined.

```
...
./model_stop.go:142:35: inlining call to common.Location.IsValid
./model_stop.go:142:35: inlining call to common.isValidLongitude
./model_stop.go:142:35: inlining call to common.isValidLatitude
...
```
In theory this is a breaking change but the API stays the same.
