### PR TITLE
Improve benchmark golden tests by sharing the model

### DIFF
--- a/tests/golden/benchmark_test.go
+++ b/tests/golden/benchmark_test.go
@@ -47,13 +47,13 @@ func BenchmarkGolden(b *testing.B) {
 			if err := json.Unmarshal(data, &input); err != nil {
 				b.Fatal(err)
 			}
+			model, err := factory.NewModel(input, factory.Options{})
+			if err != nil {
+				b.Fatal(err)
+			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				model, err := factory.NewModel(input, factory.Options{})
-				if err != nil {
-					b.Fatal(err)
-				}
 				solver, err := nextroute.NewParallelSolver(model)
 				if err != nil {
 					b.Fatal(err)


### PR DESCRIPTION
Due to some limitation in how we construct expression indices, we have to move the model create outside of the benchmark loop. Otherwise it'll blow up in terms of memory consumption on instances with multiple expressions.