### PR TITLE
Fix memory consumption when multiple models are used

### DIFF
--- a/solution_move_stops_generator.go
+++ b/solution_move_stops_generator.go
@@ -2,10 +2,6 @@
 
 package nextroute
 
-import (
-	"github.com/nextmv-io/nextroute/common"
-)
-
 // SolutionMoveStopsGeneratorChannel generates all possible moves for a given
 // vehicle and plan unit.
 //
@@ -101,12 +97,8 @@ func SolutionMoveStopsGenerator(
 	preAllocatedMoveContainer *PreAllocatedMoveContainer,
 	shouldStop func() bool,
 ) {
-	source := common.Map(stops, func(stop SolutionStop) SolutionStop {
-		return stop
-	})
-	target := common.Map(vehicle.SolutionStops(), func(stop SolutionStop) SolutionStop {
-		return stop
-	})
+	source := stops
+	target := vehicle.SolutionStops()
 	m := preAllocatedMoveContainer.singleStopPosSolutionMoveStop
 	m.(*solutionMoveStopsImpl).reset()
 	m.(*solutionMoveStopsImpl).planUnit = planUnit

--- a/solution_plan_stops_unit.go
+++ b/solution_plan_stops_unit.go
@@ -101,9 +101,7 @@ func (p *solutionPlanStopsUnitImpl) SolutionStops() SolutionStops {
 }
 
 func (p *solutionPlanStopsUnitImpl) solutionStopsImpl() []SolutionStop {
-	solutionStops := make([]SolutionStop, len(p.solutionStops))
-	copy(solutionStops, p.solutionStops)
-	return solutionStops
+	return p.solutionStops
 }
 
 func (p *solutionPlanStopsUnitImpl) IsPlanned() bool {

--- a/solution_test.go
+++ b/solution_test.go
@@ -1,0 +1,41 @@
+// © 2019-present nextmv.io inc
+
+package nextroute_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nextmv-io/nextroute"
+)
+
+func BenchmarkAllocationsSolution(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		model, err := createModel(singleVehiclePlanSequenceModel())
+		if err != nil {
+			b.Error(err)
+		}
+
+		maximum := nextroute.NewVehicleTypeDurationExpression(
+			"maximum duration",
+			3*time.Minute,
+		)
+		expression := nextroute.NewStopExpression("test", 2.0)
+
+		cnstr, err := nextroute.NewMaximum(expression, maximum)
+		if err != nil {
+			b.Error(err)
+		}
+
+		err = model.AddConstraint(cnstr)
+		if err != nil {
+			b.Error(err)
+		}
+		b.StartTimer()
+		_, err = nextroute.NewSolution(model)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This fixes a memory leak (in a way) when using multiple models within the same program with expressions.

The problem is that every expression gets an ID which is unique within the package. It uses a package global counter.
When creating a new solution we create 2 two dimensional slices with one dimension being the maximum expression ID. Every time we create anywhere a new model, this maximum expression ID increases. 

For example:
Creating a model in a loop with `n` expressions and `m` stops and solving it will slowly consume all memory since with each iteration the memory consumed when creating the first solution grows by `2 * n * m bytes`.

The benchmark test show cases that. Here I do exactly that with a very small model and even that shows already the effect. This change though comes at a cost of using a map data structure internally for now, which is more expensive.

```
name                   old time/op    new time/op    delta
AllocationsSolution-8     541µs ±28%      16µs ± 1%  -97.10%  (p=0.000 n=9+9)

name                   old alloc/op   new alloc/op   delta
AllocationsSolution-8    5.91MB ±75%    0.01MB ± 0%  -99.84%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
AllocationsSolution-8      75.0 ± 0%      77.0 ± 0%   +2.67%  (p=0.000 n=10+10)
```