### PR TITLE
Turn StopPosition into a struct

### DIFF
--- a/model_cluster.go
+++ b/model_cluster.go
@@ -217,7 +217,7 @@ func (l *clusterImpl) estimateDeltaScore(
 ) (deltaScore float64, stopPositionsHint StopPositionsHint) {
 	solutionImpl := move.Solution().(*solutionImpl)
 	moveImpl := move.(*solutionMoveStopsImpl)
-	stopPositions := moveImpl.stopPositionsImpl()
+	stopPositions := moveImpl.stopPositions
 	deltaScore = 0.0
 
 	for _, stopPosition := range stopPositions {

--- a/solution.go
+++ b/solution.go
@@ -1067,7 +1067,7 @@ func NewPreAllocatedMoveContainer(planUnit SolutionPlanUnit) *PreAllocatedMoveCo
 	switch planUnit.(type) {
 	case SolutionPlanStopsUnit:
 		m := newNotExecutableSolutionMoveStops(planUnit.(*solutionPlanStopsUnitImpl))
-		m.stopPositions = make([]stopPositionImpl, 1, 2)
+		m.stopPositions = make([]StopPosition, 1, 2)
 		allocations.singleStopPosSolutionMoveStop = m
 	case SolutionPlanUnitsUnit:
 	}

--- a/solution_move_stops.go
+++ b/solution_move_stops.go
@@ -271,9 +271,7 @@ func (m solutionMoveStopsImpl) IncrementValueSeen(inc int) SolutionMove {
 
 func (m *solutionMoveStopsImpl) StopPositions() StopPositions {
 	stopPositions := make(StopPositions, len(m.stopPositions))
-	for i, stopPosition := range m.stopPositions {
-		stopPositions[i] = stopPosition
-	}
+	copy(stopPositions, m.stopPositions)
 	return stopPositions
 }
 
@@ -622,9 +620,7 @@ func newMoveStops(
 	}
 
 	stopPositionsImpl := make([]StopPosition, len(stopPositions))
-	for i, stopPosition := range stopPositions {
-		stopPositionsImpl[i] = stopPosition
-	}
+	copy(stopPositionsImpl, stopPositions)
 	move := &solutionMoveStopsImpl{
 		planUnit:      planUnit.(*solutionPlanStopsUnitImpl),
 		stopPositions: stopPositionsImpl,

--- a/solution_move_stops.go
+++ b/solution_move_stops.go
@@ -68,21 +68,11 @@ type SolutionMoveStops interface {
 // planned). A stop position states that the stop should be moved from the
 // unplanned set to the planned set by positioning it directly before the
 // Next.
-type StopPosition interface {
-	// Previous denotes the upcoming stop's previous stop if the associated move
-	// involving the stop position is executed. It's worth noting that
-	// the previous stop may not have been planned yet.
-	Previous() SolutionStop
-
-	// Next denotes the upcoming stop's next stop if the associated move
-	// involving the stop position is executed. It's worth noting that
-	// the next stop may not have been planned yet.
-	Next() SolutionStop
-
-	// Stop returns the stop which is not yet part of the solution. This stop
-	// is not planned yet if the move where the invoking stop position belongs
-	// to, has not been executed yet.
-	Stop() SolutionStop
+type StopPosition struct {
+	solution          *solutionImpl
+	previousStopIndex int
+	stopIndex         int
+	nextStopIndex     int
 }
 
 // StopPositions is a slice of stop positions.
@@ -98,7 +88,7 @@ func newNotExecutableSolutionMoveStops(planUnit *solutionPlanStopsUnitImpl) *sol
 
 type solutionMoveStopsImpl struct {
 	planUnit      *solutionPlanStopsUnitImpl
-	stopPositions []stopPositionImpl
+	stopPositions []StopPosition
 	valueSeen     int
 	value         float64
 	allowed       bool
@@ -293,12 +283,6 @@ func (m *solutionMoveStopsImpl) StopPositionAt(index int) StopPosition {
 
 func (m *solutionMoveStopsImpl) StopPositionsLength() int {
 	return len(m.stopPositions)
-}
-
-func (m *solutionMoveStopsImpl) stopPositionsImpl() []stopPositionImpl {
-	stopPositions := make([]stopPositionImpl, len(m.stopPositions))
-	copy(stopPositions, m.stopPositions)
-	return stopPositions
 }
 
 func (m *solutionMoveStopsImpl) IsExecutable() bool {
@@ -511,14 +495,14 @@ func newMoveStops(
 		)
 	}
 
-	vehicle := stopPositions[0].(stopPositionImpl).previous().vehicle()
+	vehicle := stopPositions[0].previous().vehicle()
 
 	lastPlannedPreviousStop := stopPositions[0].Previous()
 
 	position := stopPositions[0].Previous().Position()
 
 	for index, sp := range stopPositions {
-		stopPosition := sp.(stopPositionImpl)
+		stopPosition := sp
 		if stopPosition.Stop().PlanStopsUnit() != planUnit {
 			return nil,
 				fmt.Errorf(
@@ -637,9 +621,9 @@ func newMoveStops(
 		}
 	}
 
-	stopPositionsImpl := make([]stopPositionImpl, len(stopPositions))
+	stopPositionsImpl := make([]StopPosition, len(stopPositions))
 	for i, stopPosition := range stopPositions {
-		stopPositionsImpl[i] = stopPosition.(stopPositionImpl)
+		stopPositionsImpl[i] = stopPosition
 	}
 	move := &solutionMoveStopsImpl{
 		planUnit:      planUnit.(*solutionPlanStopsUnitImpl),

--- a/solution_move_stops_generator.go
+++ b/solution_move_stops_generator.go
@@ -117,7 +117,7 @@ func SolutionMoveStopsGenerator(
 	}
 
 	// TODO: we can reuse the stopPositions slice from m
-	positions := make([]stopPositionImpl, len(source))
+	positions := make([]StopPosition, len(source))
 	for idx := range source {
 		positions[idx].stopIndex = source[idx].index
 		positions[idx].solution = source[idx].solution
@@ -181,7 +181,7 @@ func mustBeNeighbours(model *modelImpl, from, to solutionStopImpl) bool {
 }
 
 func generate(
-	stopPositions []stopPositionImpl,
+	stopPositions []StopPosition,
 	combination []int,
 	source []solutionStopImpl,
 	target []solutionStopImpl,

--- a/solution_plan_stops_unit.go
+++ b/solution_plan_stops_unit.go
@@ -184,7 +184,7 @@ func (p *solutionPlanStopsUnitImpl) StopPositions() StopPositions {
 var unplanSolutionMove = sync.Pool{
 	New: func() any {
 		return &solutionMoveStopsImpl{
-			stopPositions: make([]stopPositionImpl, 0, 64),
+			stopPositions: make([]StopPosition, 0, 64),
 		}
 	},
 }

--- a/solution_stop_generator.go
+++ b/solution_stop_generator.go
@@ -75,7 +75,7 @@ func newSolutionStopGenerator(
 
 type solutionStopGeneratorImpl struct {
 	nextStop                solutionStopImpl
-	stopPositions           []stopPositionImpl
+	stopPositions           []StopPosition
 	activeStopPositionIndex int
 	startAtFirst            bool
 	endAtLast               bool

--- a/solution_stop_position.go
+++ b/solution_stop_position.go
@@ -13,45 +13,45 @@ func NewStopPosition(
 	n SolutionStop,
 ) (StopPosition, error) {
 	if p == nil {
-		return nil, fmt.Errorf("previous stop is nil")
+		return StopPosition{}, fmt.Errorf("previous stop is nil")
 	}
 	if s == nil {
-		return nil, fmt.Errorf("stop is nil")
+		return StopPosition{}, fmt.Errorf("stop is nil")
 	}
 	if n == nil {
-		return nil, fmt.Errorf("next stop is nil")
+		return StopPosition{}, fmt.Errorf("next stop is nil")
 	}
 	previous := p.(solutionStopImpl)
 	stop := s.(solutionStopImpl)
 	next := n.(solutionStopImpl)
 	if previous.Solution() != stop.Solution() {
-		return nil, fmt.Errorf(
+		return StopPosition{}, fmt.Errorf(
 			"previous %v and stop %v are on different solutions",
 			previous,
 			stop,
 		)
 	}
 	if stop.Solution() != next.Solution() {
-		return nil, fmt.Errorf(
+		return StopPosition{}, fmt.Errorf(
 			"stop %v and next %v are on different solutions",
 			stop,
 			next,
 		)
 	}
 	if stop.IsPlanned() {
-		return nil, fmt.Errorf("stop %v is planned", stop)
+		return StopPosition{}, fmt.Errorf("stop %v is planned", stop)
 	}
 	if previous.IsPlanned() &&
 		next.IsPlanned() {
 		if previous.vehicle().index != next.vehicle().index {
-			return nil, fmt.Errorf(
+			return StopPosition{}, fmt.Errorf(
 				"previous %v and next %v are planned but on different vehicle",
 				previous,
 				next,
 			)
 		}
 		if previous.Position() >= next.Position() {
-			return nil, fmt.Errorf(
+			return StopPosition{}, fmt.Errorf(
 				"previous %v and next %v are planned but previous is not before next",
 				previous,
 				next,
@@ -65,8 +65,8 @@ func newStopPosition(
 	previous solutionStopImpl,
 	stop solutionStopImpl,
 	next solutionStopImpl,
-) stopPositionImpl {
-	return stopPositionImpl{
+) StopPosition {
+	return StopPosition{
 		previousStopIndex: previous.index,
 		stopIndex:         stop.index,
 		nextStopIndex:     next.index,
@@ -74,14 +74,7 @@ func newStopPosition(
 	}
 }
 
-type stopPositionImpl struct {
-	solution          *solutionImpl
-	previousStopIndex int
-	stopIndex         int
-	nextStopIndex     int
-}
-
-func (v stopPositionImpl) String() string {
+func (v StopPosition) String() string {
 	return fmt.Sprintf("stopPosition{%s[%v]->%s[%v]->%s[%v]",
 		v.previous().ModelStop().ID(),
 		v.previous().Index(),
@@ -92,33 +85,42 @@ func (v stopPositionImpl) String() string {
 	)
 }
 
-func (v stopPositionImpl) Previous() SolutionStop {
+// Previous denotes the upcoming stop's previous stop if the associated move
+// involving the stop position is executed. It's worth noting that
+// the previous stop may not have been planned yet.
+func (v StopPosition) Previous() SolutionStop {
 	return v.solution.stopByIndexCache[v.previousStopIndex]
 }
 
-func (v stopPositionImpl) Next() SolutionStop {
+// Next denotes the upcoming stop's next stop if the associated move
+// involving the stop position is executed. It's worth noting that
+// the next stop may not have been planned yet.
+func (v StopPosition) Next() SolutionStop {
 	return v.solution.stopByIndexCache[v.nextStopIndex]
 }
 
-func (v stopPositionImpl) Stop() SolutionStop {
+// Stop returns the stop which is not yet part of the solution. This stop
+// is not planned yet if the move where the invoking stop position belongs
+// to, has not been executed yet.
+func (v StopPosition) Stop() SolutionStop {
 	return v.solution.stopByIndexCache[v.stopIndex]
 }
 
-func (v stopPositionImpl) previous() solutionStopImpl {
+func (v StopPosition) previous() solutionStopImpl {
 	return solutionStopImpl{
 		index:    v.previousStopIndex,
 		solution: v.solution,
 	}
 }
 
-func (v stopPositionImpl) next() solutionStopImpl {
+func (v StopPosition) next() solutionStopImpl {
 	return solutionStopImpl{
 		index:    v.nextStopIndex,
 		solution: v.solution,
 	}
 }
 
-func (v stopPositionImpl) stop() solutionStopImpl {
+func (v StopPosition) stop() solutionStopImpl {
 	return solutionStopImpl{
 		index:    v.stopIndex,
 		solution: v.solution,

--- a/solution_vehicle.go
+++ b/solution_vehicle.go
@@ -246,7 +246,7 @@ func (v solutionVehicleImpl) bestMovePlanSingleStop(
 	// ensure that stopPositions is a length 1 slice
 	move.(*solutionMoveStopsImpl).stopPositions = append(
 		move.(*solutionMoveStopsImpl).stopPositions,
-		stopPositionImpl{},
+		StopPosition{},
 	)
 	stop := v.first()
 
@@ -658,7 +658,7 @@ func (v solutionVehicleImpl) Unplan() (bool, error) {
 	}
 	if constraint != nil {
 		for i := len(stopPositions) - 1; i >= 0; i-- {
-			stopPosition := stopPositions[i].(stopPositionImpl)
+			stopPosition := stopPositions[i]
 			beforeStop := stopPosition.next()
 			stopPosition.stop().attach(
 				beforeStop.PreviousIndex(),


### PR DESCRIPTION
This turns the `StopPosition` interface into a struct.

All benchmarks point to a performance increase and this change will later allow us to further simplify internals.