### PR TITLE
Decrease allocations in copy solution

### DIFF
--- a/common/slices.go
+++ b/common/slices.go
@@ -1,0 +1,13 @@
+// © 2019-present nextmv.io inc
+
+package common
+
+// CopySliceFrom cuts of a slice from `alloc` and copies the data from `data`
+// into it. It returns the new slice and the remaining slice of `alloc`. This
+// can be used in places where we allocate once and copy multiple times.
+func CopySliceFrom[T any](alloc []T, data []T) ([]T, []T) {
+	n := len(data)
+	newData, alloc := alloc[:n], alloc[n:]
+	copy(newData, data)
+	return newData, alloc
+}


### PR DESCRIPTION
This explores the use of a different allocation strategy when copying the solution.

Instead of allocating smaller slices multiple times (7 int slices and 5 float slices), we allocate 2 big slices.
This definitely reduces the number of allocations (12 -> 2). Some isolated tests indicate that this is also significantly faster (in particular with larger number of stops/vehicles), but it remains to be seen if that really makes a difference compared to all the other work that is being done.

Benchmarks suggests a good win in performance here on instances that have a lot of solutions.