### PR TITLE
Turn SolutionStop into a struct

### DIFF
--- a/model_cluster.go
+++ b/model_cluster.go
@@ -104,17 +104,17 @@ func (l *clusterImpl) EstimationCost() Cost {
 func (l *clusterImpl) UpdateObjectiveStopData(
 	solutionStop SolutionStop,
 ) (Copier, error) {
-	return l.updateData(solutionStop.(solutionStopImpl), true)
+	return l.updateData(solutionStop, true)
 }
 
 func (l *clusterImpl) UpdateConstraintStopData(
 	solutionStop SolutionStop,
 ) (Copier, error) {
-	return l.updateData(solutionStop.(solutionStopImpl), false)
+	return l.updateData(solutionStop, false)
 }
 
 func (l *clusterImpl) updateData(
-	solutionStop solutionStopImpl,
+	solutionStop SolutionStop,
 	asObjective bool,
 ) (Copier, error) {
 	if solutionStop.IsFirst() {
@@ -129,21 +129,21 @@ func (l *clusterImpl) updateData(
 
 	if solutionStop.IsLast() {
 		if asObjective {
-			centroid := solutionStop.previous().ObjectiveData(l).(*centroidData)
+			centroid := solutionStop.Previous().ObjectiveData(l).(*centroidData)
 			stops := l.getSolutionStops(solutionStop.vehicle())
-			compact := compactness(stops, centroid.location, solutionStopImpl{}, false)
+			compact := compactness(stops, centroid.location, SolutionStop{}, false)
 			centroid.compactness = compact
 			return centroid, nil
 		}
-		return solutionStop.previous().ConstraintData(l).(*centroidData), nil
+		return solutionStop.Previous().ConstraintData(l).(*centroidData), nil
 	}
 	nrStops := solutionStop.Position()
 
 	var centroid *centroidData
 	if asObjective {
-		centroid = solutionStop.previous().ObjectiveData(l).(*centroidData)
+		centroid = solutionStop.Previous().ObjectiveData(l).(*centroidData)
 	} else {
-		centroid = solutionStop.previous().ConstraintData(l).(*centroidData)
+		centroid = solutionStop.Previous().ConstraintData(l).(*centroidData)
 	}
 
 	location, err := common.NewLocation(
@@ -164,9 +164,9 @@ func (l *clusterImpl) updateData(
 }
 
 func compactness(
-	stops []solutionStopImpl,
+	stops []SolutionStop,
 	centroid common.Location,
-	newStop solutionStopImpl,
+	newStop SolutionStop,
 	newStopIsSet bool,
 ) float64 {
 	if newStopIsSet {
@@ -270,8 +270,8 @@ func (l *clusterImpl) estimateDeltaScore(
 	return deltaScore, constNoPositionsHint
 }
 
-func (l *clusterImpl) getSolutionStops(vehicle SolutionVehicle) []solutionStopImpl {
-	stops := make([]solutionStopImpl, 0, vehicle.NumberOfStops())
+func (l *clusterImpl) getSolutionStops(vehicle SolutionVehicle) []SolutionStop {
+	stops := make([]SolutionStop, 0, vehicle.NumberOfStops())
 	for _, stop := range vehicle.SolutionStops() {
 		if stop.IsFirst() && !l.includeFirst {
 			continue
@@ -279,7 +279,7 @@ func (l *clusterImpl) getSolutionStops(vehicle SolutionVehicle) []solutionStopIm
 		if stop.IsLast() && !l.includeLast {
 			continue
 		}
-		stops = append(stops, stop.(solutionStopImpl))
+		stops = append(stops, stop)
 	}
 	return stops
 }

--- a/model_constraint_maximum_wait_stop.go
+++ b/model_constraint_maximum_wait_stop.go
@@ -104,7 +104,7 @@ func (l *maximumWaitStopConstraintImpl) EstimateIsViolated(
 }
 
 func (l *maximumWaitStopConstraintImpl) DoesStopHaveViolations(s SolutionStop) bool {
-	stop := s.(solutionStopImpl)
+	stop := s
 	return stop.StartValue()-stop.ArrivalValue() >
 		l.maxima.Value(nil, nil, stop.modelStop())
 }

--- a/model_constraint_maximum_wait_vehicle.go
+++ b/model_constraint_maximum_wait_vehicle.go
@@ -139,7 +139,7 @@ func (l *maximumWaitVehicleConstraintImpl) EstimateIsViolated(
 }
 
 func (l *maximumWaitVehicleConstraintImpl) DoesStopHaveViolations(solution SolutionStop) bool {
-	stop := solution.(solutionStopImpl)
+	stop := solution
 	return stop.ConstraintData(l).(*maximumWaitVehicleConstraintData).accumulatedWait >
 		l.maxima.Value(stop.vehicle().ModelVehicle().VehicleType(), nil, nil)
 }

--- a/model_constraint_no_mix.go
+++ b/model_constraint_no_mix.go
@@ -225,7 +225,7 @@ func (l *noMixConstraintImpl) Value(solutionStop SolutionStop) MixItem {
 func (l *noMixConstraintImpl) UpdateConstraintStopData(
 	solutionStop SolutionStop,
 ) (Copier, error) {
-	solutionStopImp := solutionStop.(solutionStopImpl)
+	solutionStopImp := solutionStop
 
 	if solutionStopImp.IsFirst() {
 		return &noMixSolutionStopData{
@@ -238,7 +238,7 @@ func (l *noMixConstraintImpl) UpdateConstraintStopData(
 		}, nil
 	}
 
-	previousNoMixData := solutionStopImp.previous().ConstraintData(l).(*noMixSolutionStopData)
+	previousNoMixData := solutionStopImp.Previous().ConstraintData(l).(*noMixSolutionStopData)
 
 	insertMixIngredient, hasInsertMixIngredient := l.insert[solutionStop.ModelStop()]
 	if hasInsertMixIngredient {

--- a/model_constraint_successors.go
+++ b/model_constraint_successors.go
@@ -92,8 +92,8 @@ func (l *successorConstraintImpl) DoesStopHaveViolations(
 	stop SolutionStop,
 ) bool {
 	modelImpl := stop.Solution().Model().(*modelImpl)
-	stopImpl := stop.(solutionStopImpl)
-	previousModelStop := stopImpl.previous().modelStop()
+	stopImpl := stop
+	previousModelStop := stopImpl.Previous().modelStop()
 	if disallowed := modelImpl.disallowedSuccessors[previousModelStop.Index()][stop.ModelStop().Index()]; disallowed {
 		return true
 	}

--- a/model_latest.go
+++ b/model_latest.go
@@ -190,7 +190,7 @@ func (l *latestImpl) Value(s Solution) float64 {
 	solution := s.(*solutionImpl)
 	value := 0.0
 	for _, vehicle := range solution.vehicles {
-		solutionStop := vehicle.first().next()
+		solutionStop := vehicle.first().Next()
 		lastSolutionStop := vehicle.last()
 		for {
 			latenessFactor := l.latenessFactor.Value(
@@ -204,7 +204,7 @@ func (l *latestImpl) Value(s Solution) float64 {
 				break
 			}
 
-			solutionStop = solutionStop.next()
+			solutionStop = solutionStop.Next()
 		}
 	}
 
@@ -306,7 +306,7 @@ func (l *latestImpl) estimateDeltaScore(
 }
 
 func (l *latestImpl) DoesStopHaveViolations(s SolutionStop) bool {
-	stop := s.(solutionStopImpl)
+	stop := s
 	if !stop.
 		vehicle().
 		ModelVehicle().

--- a/model_maximum.go
+++ b/model_maximum.go
@@ -161,7 +161,7 @@ func (l *maximumImpl) Maximum() VehicleTypeExpression {
 }
 
 func (l *maximumImpl) DoesStopHaveViolations(s SolutionStop) bool {
-	stop := s.(solutionStopImpl)
+	stop := s
 	// We check if the cumulative value is below zero or above the maximum.
 	// If there are stops with negative values, the cumulative value can be
 	// below zero. Un-planning can result in a cumulative value below zero
@@ -248,7 +248,7 @@ func (l *maximumImpl) EstimateIsViolated(
 	stop, _ := moveImpl.next()
 
 	if stop.CumulativeValue(expression) != level {
-		stop = stop.next()
+		stop = stop.Next()
 
 		for !stop.IsLast() {
 			level += stop.Value(expression)
@@ -258,7 +258,7 @@ func (l *maximumImpl) EstimateIsViolated(
 				return true, constNoPositionsHint
 			}
 
-			stop = stop.next()
+			stop = stop.Next()
 		}
 	}
 

--- a/model_objective_earliness.go
+++ b/model_objective_earliness.go
@@ -78,10 +78,10 @@ func (l *earlinessObjectiveImpl) TargetTime() StopTimeExpression {
 }
 
 func (l *earlinessObjectiveImpl) Earliness(stop SolutionStop) float64 {
-	return l.earliness(stop.(solutionStopImpl))
+	return l.earliness(stop)
 }
 
-func (l *earlinessObjectiveImpl) earliness(stop solutionStopImpl) float64 {
+func (l *earlinessObjectiveImpl) earliness(stop SolutionStop) float64 {
 	targetTime := l.targetTime.Value(nil, nil, stop.modelStop())
 	compare := 0.
 	switch l.temporalReference {

--- a/model_objective_expression.go
+++ b/model_objective_expression.go
@@ -52,7 +52,7 @@ func (e *expressionObjectiveImpl) EstimateDeltaValue(
 	value := 0.0
 
 	first := true
-	var previousSolutionStop solutionStopImpl
+	var previousSolutionStop SolutionStop
 
 	generator := newSolutionStopGenerator(*moveImpl, false, false)
 	defer generator.release()

--- a/model_objective_vehicles_duration.go
+++ b/model_objective_vehicles_duration.go
@@ -86,10 +86,10 @@ func (t *vehiclesDurationObjectiveImpl) EstimateDeltaValue(
 		return end - vehicle.last().EndValue()
 	}
 
-	for solutionStop := nextmove.next(); !solutionStop.IsLast(); solutionStop = solutionStop.next() {
+	for solutionStop := nextmove.Next(); !solutionStop.IsLast(); solutionStop = solutionStop.Next() {
 		_, _, _, end = vehicleType.TemporalValues(
 			end,
-			solutionStop.previous().ModelStop(),
+			solutionStop.Previous().ModelStop(),
 			solutionStop.ModelStop(),
 		)
 		tempEnd := solutionStop.EndValue()
@@ -102,7 +102,7 @@ func (t *vehiclesDurationObjectiveImpl) EstimateDeltaValue(
 	last := vehicle.last()
 	_, _, _, end = vehicleType.TemporalValues(
 		end,
-		last.previous().ModelStop(),
+		last.Previous().ModelStop(),
 		last.ModelStop(),
 	)
 

--- a/solution_move_stops.go
+++ b/solution_move_stops.go
@@ -143,12 +143,12 @@ func (m *solutionMoveStopsImpl) Next() SolutionStop {
 	if next, ok := m.next(); ok {
 		return next
 	}
-	return nil
+	return SolutionStop{}
 }
 
-func (m *solutionMoveStopsImpl) next() (solutionStopImpl, bool) {
+func (m *solutionMoveStopsImpl) next() (SolutionStop, bool) {
 	if len(m.stopPositions) == 0 {
-		return solutionStopImpl{}, false
+		return SolutionStop{}, false
 	}
 	return m.stopPositions[len(m.stopPositions)-1].next(), true
 }
@@ -156,14 +156,14 @@ func (m *solutionMoveStopsImpl) next() (solutionStopImpl, bool) {
 func (m *solutionMoveStopsImpl) Previous() SolutionStop {
 	previous, ok := m.previous()
 	if !ok {
-		return nil
+		return SolutionStop{}
 	}
 	return previous
 }
 
-func (m *solutionMoveStopsImpl) previous() (solutionStopImpl, bool) {
+func (m *solutionMoveStopsImpl) previous() (SolutionStop, bool) {
 	if len(m.stopPositions) == 0 {
-		return solutionStopImpl{}, false
+		return SolutionStop{}, false
 	}
 	return m.stopPositions[0].previous(), true
 }

--- a/solution_move_stops_generator.go
+++ b/solution_move_stops_generator.go
@@ -101,11 +101,11 @@ func SolutionMoveStopsGenerator(
 	preAllocatedMoveContainer *PreAllocatedMoveContainer,
 	shouldStop func() bool,
 ) {
-	source := common.Map(stops, func(stop SolutionStop) solutionStopImpl {
-		return stop.(solutionStopImpl)
+	source := common.Map(stops, func(stop SolutionStop) SolutionStop {
+		return stop
 	})
-	target := common.Map(vehicle.SolutionStops(), func(stop SolutionStop) solutionStopImpl {
-		return stop.(solutionStopImpl)
+	target := common.Map(vehicle.SolutionStops(), func(stop SolutionStop) SolutionStop {
+		return stop
 	})
 	m := preAllocatedMoveContainer.singleStopPosSolutionMoveStop
 	m.(*solutionMoveStopsImpl).reset()
@@ -157,14 +157,14 @@ func SolutionMoveStopsGenerator(
 	}
 }
 
-func isNotAllowed(model *modelImpl, from, to solutionStopImpl) bool {
+func isNotAllowed(model *modelImpl, from, to SolutionStop) bool {
 	if !model.hasDisallowedSuccessors() {
 		return false
 	}
 	return model.disallowedSuccessors[from.ModelStopIndex()][to.ModelStopIndex()]
 }
 
-func mustBeNeighbours(model *modelImpl, from, to solutionStopImpl) bool {
+func mustBeNeighbours(model *modelImpl, from, to SolutionStop) bool {
 	if !model.hasDirectSuccessors {
 		return false
 	}
@@ -183,8 +183,8 @@ func mustBeNeighbours(model *modelImpl, from, to solutionStopImpl) bool {
 func generate(
 	stopPositions []StopPosition,
 	combination []int,
-	source []solutionStopImpl,
-	target []solutionStopImpl,
+	source []SolutionStop,
+	target []SolutionStop,
 	yield func(),
 	shouldStop func() bool,
 ) {

--- a/solution_plan_stops_unit.go
+++ b/solution_plan_stops_unit.go
@@ -34,7 +34,7 @@ type SolutionPlanStopsUnits []SolutionPlanStopsUnit
 
 type solutionPlanStopsUnitImpl struct {
 	modelPlanStopsUnit ModelPlanStopsUnit
-	solutionStops      []solutionStopImpl
+	solutionStops      []SolutionStop
 }
 
 func (p *solutionPlanStopsUnitImpl) String() string {
@@ -48,7 +48,7 @@ func (p *solutionPlanStopsUnitImpl) SolutionStop(stop ModelStop) SolutionStop {
 	return p.solutionStop(stop)
 }
 
-func (p *solutionPlanStopsUnitImpl) solutionStop(stop ModelStop) solutionStopImpl {
+func (p *solutionPlanStopsUnitImpl) solutionStop(stop ModelStop) SolutionStop {
 	for _, solutionStop := range p.solutionStops {
 		if solutionStop.ModelStop().Index() == stop.Index() {
 			return solutionStop
@@ -102,8 +102,8 @@ func (p *solutionPlanStopsUnitImpl) SolutionStops() SolutionStops {
 	return solutionStops
 }
 
-func (p *solutionPlanStopsUnitImpl) solutionStopsImpl() []solutionStopImpl {
-	solutionStops := make([]solutionStopImpl, len(p.solutionStops))
+func (p *solutionPlanStopsUnitImpl) solutionStopsImpl() []SolutionStop {
+	solutionStops := make([]SolutionStop, len(p.solutionStops))
 	copy(solutionStops, p.solutionStops)
 	return solutionStops
 }
@@ -170,11 +170,11 @@ func (p *solutionPlanStopsUnitImpl) UnPlan() (bool, error) {
 
 func (p *solutionPlanStopsUnitImpl) StopPositions() StopPositions {
 	if p.IsPlanned() {
-		return common.Map(p.solutionStops, func(solutionStop solutionStopImpl) StopPosition {
+		return common.Map(p.solutionStops, func(solutionStop SolutionStop) StopPosition {
 			return newStopPosition(
-				solutionStop.previous(),
+				solutionStop.Previous(),
 				solutionStop,
-				solutionStop.next(),
+				solutionStop.Next(),
 			)
 		})
 	}
@@ -206,9 +206,9 @@ func (p *solutionPlanStopsUnitImpl) unplan() (bool, error) {
 	move.allowed = true
 	for _, solutionStop := range p.solutionStops {
 		move.stopPositions = append(move.stopPositions, newStopPosition(
-			solutionStop.previous(),
+			solutionStop.Previous(),
 			solutionStop,
-			solutionStop.next(),
+			solutionStop.Next(),
 		))
 	}
 

--- a/solution_plan_stops_unit.go
+++ b/solution_plan_stops_unit.go
@@ -96,9 +96,7 @@ func (p *solutionPlanStopsUnitImpl) Stops() ModelStops {
 
 func (p *solutionPlanStopsUnitImpl) SolutionStops() SolutionStops {
 	solutionStops := make(SolutionStops, len(p.solutionStops))
-	for i, solutionStop := range p.solutionStops {
-		solutionStops[i] = solutionStop
-	}
+	copy(solutionStops, p.solutionStops)
 	return solutionStops
 }
 

--- a/solution_plan_unit.go
+++ b/solution_plan_unit.go
@@ -53,10 +53,10 @@ func copySolutionPlanStopsUnit(
 	solutionPlanUnitImpl := solutionPlanUnit.(*solutionPlanStopsUnitImpl)
 	copyOfSolutionPlanUnit := &solutionPlanStopsUnitImpl{
 		modelPlanStopsUnit: solutionPlanUnitImpl.modelPlanStopsUnit,
-		solutionStops:      make([]solutionStopImpl, len(solutionPlanUnitImpl.solutionStops)),
+		solutionStops:      make([]SolutionStop, len(solutionPlanUnitImpl.solutionStops)),
 	}
 	for idx, solutionStop := range solutionPlanUnitImpl.solutionStops {
-		copyOfSolutionPlanUnit.solutionStops[idx] = solutionStopImpl{
+		copyOfSolutionPlanUnit.solutionStops[idx] = SolutionStop{
 			index:    solutionStop.Index(),
 			solution: solution,
 		}

--- a/solution_stop.go
+++ b/solution_stop.go
@@ -10,168 +10,22 @@ import (
 
 // A SolutionStop is a stop that is planned to be visited by a vehicle. It is
 // part of a SolutionPlanUnit and is based on a ModelStop.
-type SolutionStop interface {
-	// Arrival returns the arrival time of the stop. If the stop is unplanned,
-	// the arrival time has no semantic meaning.
-	Arrival() time.Time
-	// ArrivalValue returns the arrival time of the stop as a float64. If the
-	// stop is unplanned, the arrival time has no semantic meaning.
-	ArrivalValue() float64
-
-	// ConstraintData returns the value of the constraint for the stop. The
-	// constraint value of a stop is set by the ConstraintStopDataUpdater.
-	// UpdateConstrainStopData method of the constraint. If the constraint is
-	// not set on the stop, nil is returned. If the stop is unplanned, the
-	// constraint value has no semantic meaning.
-	ConstraintData(constraint ModelConstraint) any
-	// CumulativeTravelDurationValue returns the cumulative travel duration of
-	// the stop as a float64. The cumulative travel duration is the sum of the
-	// travel durations of all stops that are visited before the stop. If the
-	// stop is unplanned, the cumulative travel duration has no semantic
-	// meaning. The returned value is the number of Model.DurationUnit units.
-	CumulativeTravelDurationValue() float64
-	// CumulativeTravelDuration returns the cumulative value of the expression
-	// for the stop as a time.Duration. The cumulative travel duration is the
-	// sum of the travel durations of all stops that are visited before the
-	// stop and the stop itself. If the stop is unplanned, the cumulative
-	// travel duration has no semantic meaning.
-	CumulativeTravelDuration() time.Duration
-	// CumulativeValue returns the cumulative value of the expression for the
-	// stop as a float64. The cumulative value is the sum of the values of the
-	// expression for all stops that are visited before the stop and the stop
-	// itself. If the stop is unplanned, the cumulative value has no semantic
-	// meaning.
-	CumulativeValue(expression ModelExpression) float64
-
-	// DurationValue returns the duration of the stop as a float64. If the stop
-	// is unplanned, the duration has no semantic meaning.
-	DurationValue() float64
-
-	// End returns the end time of the stop. If the stop is unplanned, the end
-	// time has no semantic meaning.
-	End() time.Time
-	// EndValue returns the end time of the stop as a float64. If the stop is
-	// unplanned, the end time has no semantic meaning. The returned value is
-	// the number of Model.DurationUnit units since Model.Epoch.
-	EndValue() float64
-
-	// Index returns the index of the stop in the Solution.
-	Index() int
-	// IsFixed returns true if the stop is fixed. A fixed stop is a stop that
-	// that can not transition form being planned to unplanned or vice versa.
-	IsFixed() bool
-	// IsFirst returns true if the stop is the first stop of a vehicle.
-	IsFirst() bool
-	// IsLast returns true if the stop is the last stop of a vehicle.
-	IsLast() bool
-	// IsPlanned returns true if the stop is planned. A planned stop is a stop
-	// that is visited by a vehicle. An unplanned stop is a stop that is not
-	// visited by a vehicle.
-	IsPlanned() bool
-
-	// ModelStop returns the ModelStop that is the basis of the SolutionStop.
-	ModelStop() ModelStop
-	// ModelStopIndex is the index of the ModelStop in the Model.
-	ModelStopIndex() int
-
-	// Next returns the next stop the vehicle will visit after the stop. If
-	// the stop is the last stop of a vehicle, the solution stop itself is
-	// returned. If the stop is unplanned, the next stop has no semantic
-	// meaning and the stop itself is returned.
-	Next() SolutionStop
-	// NextIndex returns the index of the next solution stop the vehicle will
-	// visit after the stop. If the stop is the last stop of a vehicle,
-	// the index of the stop itself is returned. If the stop is unplanned,
-	// the next stop has no semantic meaning and the index of the stop itself
-	// is returned.
-	NextIndex() int
-
-	// ObjectiveData returns the value of the objective for the stop. The
-	// objective value of a stop is set by the
-	// ObjectiveStopDataUpdater.UpdateObjectiveStopData method of the objective.
-	// If the objective is not set on the stop, nil is returned. If the stop is
-	// unplanned, the objective value has no semantic meaning.
-	ObjectiveData(objective ModelObjective) any
-
-	// PlanStopsUnit returns the [SolutionPlanStopsUnit] that the stop is
-	// associated with.
-	PlanStopsUnit() SolutionPlanStopsUnit
-	// Previous returns the previous stop the vehicle visited before the stop.
-	// If the stop is the first stop of a vehicle, the solution stop itself is
-	// returned. If the stop is unplanned, the previous stop has no semantic
-	// meaning and the stop itself is returned.
-	Previous() SolutionStop
-	// PreviousIndex returns the index of the previous solution stop the
-	// vehicle visited before the stop. If the stop is the first stop of a
-	// vehicle, the index of the stop itself is returned. If the stop is
-	// unplanned, the previous stop has no semantic meaning and the index of
-	// the stop itself is returned.
-	PreviousIndex() int
-
-	// Slack returns the slack of the stop as a time.Duration. Slack is defined
-	// as the duration you can start the invoking stop later without
-	// postponing the last stop of the vehicle. If the stop is unplanned,
-	// the slack has no semantic meaning. Slack is a consequence of the
-	// earliest start of stops, if no earliest start is set, the slack is
-	// always zero.
-	Slack() time.Duration
-	// SlackValue returns the slack of the stop as a float64.
-	SlackValue() float64
-
-	// Vehicle returns the SolutionVehicle that visits the stop. If the stop
-	// is unplanned, the vehicle has no semantic meaning and a panic will be
-	// raised.
-	Vehicle() SolutionVehicle
-	// VehicleIndex returns the index of the SolutionVehicle that visits the
-	// stop. If the stop is unplanned, a panic will be raised.
-	VehicleIndex() int
-
-	// Solution returns the Solution that the stop is part of.
-	Solution() Solution
-	// Start returns the start time of the stop. If the stop is unplanned, the
-	// start time has no semantic meaning.
-	Start() time.Time
-	// StartValue returns the start time of the stop as a float64. If the stop
-	// is unplanned, the start time has no semantic meaning. The returned
-	// value is the number of Model.DurationUnit units since Model.Epoch.
-	StartValue() float64
-	// Position returns the position of the stop in the vehicle starting with
-	// 0 for the first stop. If the stop is unplanned, a panic will be raised.
-	Position() int
-
-	// TravelDuration returns the travel duration of the stop as a
-	// time.Duration. If the stop is unplanned, the travel duration has no
-	// semantic meaning. The travel duration is the time it takes to get to
-	// the invoking stop.
-	TravelDuration() time.Duration
-	// TravelDurationValue returns the travel duration of the stop as a
-	// float64. If the stop is unplanned, the travel duration has no semantic
-	// meaning. The travel duration is the time it takes to get to the
-	// invoking stop. The returned value is the number of
-	// Model.DurationUnit units.
-	TravelDurationValue() float64
-
-	// Value returns the value of the expression for the stop as a float64.
-	// If the stop is unplanned, the value has no semantic meaning.
-	Value(expression ModelExpression) float64
+type SolutionStop struct {
+	solution *solutionImpl
+	index    int
 }
 
 // SolutionStops is a slice of SolutionStop.
 type SolutionStops []SolutionStop
 
-type solutionStopImpl struct {
-	solution *solutionImpl
-	index    int
-}
-
-func toSolutionStop(solution Solution, index int) solutionStopImpl {
-	return solutionStopImpl{
+func toSolutionStop(solution Solution, index int) SolutionStop {
+	return SolutionStop{
 		index:    index,
 		solution: solution.(*solutionImpl),
 	}
 }
 
-func (v solutionStopImpl) String() string {
+func (v SolutionStop) String() string {
 	var sb strings.Builder
 	if v.solution.next[v.index] != v.solution.previous[v.index] {
 		fmt.Fprintf(&sb, "%v;%v;%v;%v;%v;%v;%v",
@@ -191,85 +45,123 @@ func (v solutionStopImpl) String() string {
 	return sb.String()
 }
 
-func (v solutionStopImpl) ConstraintData(
+// ConstraintData returns the value of the constraint for the stop. The
+// constraint value of a stop is set by the ConstraintStopDataUpdater.
+// UpdateConstrainStopData method of the constraint. If the constraint is
+// not set on the stop, nil is returned. If the stop is unplanned, the
+// constraint value has no semantic meaning.
+func (v SolutionStop) ConstraintData(
 	constraint ModelConstraint,
 ) any {
 	return v.solution.constraintValue(constraint, v.index)
 }
 
-func (v solutionStopImpl) ObjectiveData(
+// ObjectiveData returns the value of the objective for the stop. The
+// objective value of a stop is set by the
+// ObjectiveStopDataUpdater.UpdateObjectiveStopData method of the objective.
+// If the objective is not set on the stop, nil is returned. If the stop is
+// unplanned, the objective value has no semantic meaning.
+func (v SolutionStop) ObjectiveData(
 	objective ModelObjective,
 ) any {
 	return v.solution.objectiveValue(objective, v.index)
 }
 
-func (v solutionStopImpl) Value(
+// Value returns the value of the expression for the stop as a float64.
+// If the stop is unplanned, the value has no semantic meaning.
+func (v SolutionStop) Value(
 	expression ModelExpression,
 ) float64 {
 	return v.solution.value(expression, v.index)
 }
 
-func (v solutionStopImpl) CumulativeValue(
+// CumulativeValue returns the cumulative value of the expression for the
+// stop as a float64. The cumulative value is the sum of the values of the
+// expression for all stops that are visited before the stop and the stop
+// itself. If the stop is unplanned, the cumulative value has no semantic
+// meaning.
+func (v SolutionStop) CumulativeValue(
 	expression ModelExpression,
 ) float64 {
 	return v.solution.cumulativeValue(expression, v.index)
 }
 
-func (v solutionStopImpl) Solution() Solution {
+// Solution returns the Solution that the stop is part of.
+func (v SolutionStop) Solution() Solution {
 	return v.solution
 }
 
-func (v solutionStopImpl) PlanStopsUnit() SolutionPlanStopsUnit {
+// PlanStopsUnit returns the [SolutionPlanStopsUnit] that the stop is
+// associated with.
+func (v SolutionStop) PlanStopsUnit() SolutionPlanStopsUnit {
 	return v.planStopsUnit()
 }
 
-func (v solutionStopImpl) planStopsUnit() *solutionPlanStopsUnitImpl {
+func (v SolutionStop) planStopsUnit() *solutionPlanStopsUnitImpl {
 	return v.solution.stopToPlanUnit[v.index]
 }
 
-func (v solutionStopImpl) Index() int {
+// Index returns the index of the stop in the Solution.
+func (v SolutionStop) Index() int {
 	return v.index
 }
 
-func (v solutionStopImpl) Next() SolutionStop {
-	return v.solution.stopByIndexCache[v.solution.next[v.index]]
-}
-
-func (v solutionStopImpl) next() solutionStopImpl {
-	return solutionStopImpl{
+// Next returns the next stop the vehicle will visit after the stop. If
+// the stop is the last stop of a vehicle, the solution stop itself is
+// returned. If the stop is unplanned, the next stop has no semantic
+// meaning and the stop itself is returned.
+func (v SolutionStop) Next() SolutionStop {
+	return SolutionStop{
 		index:    v.solution.next[v.index],
 		solution: v.solution,
 	}
 }
 
-func (v solutionStopImpl) NextIndex() int {
+// NextIndex returns the index of the next solution stop the vehicle will
+// visit after the stop. If the stop is the last stop of a vehicle,
+// the index of the stop itself is returned. If the stop is unplanned,
+// the next stop has no semantic meaning and the index of the stop itself
+// is returned.
+func (v SolutionStop) NextIndex() int {
 	return v.solution.next[v.index]
 }
 
-func (v solutionStopImpl) IsPlanned() bool {
+// IsPlanned returns true if the stop is planned. A planned stop is a stop
+// that is visited by a vehicle. An unplanned stop is a stop that is not
+// visited by a vehicle.
+func (v SolutionStop) IsPlanned() bool {
 	return v.solution.next[v.index] != v.solution.previous[v.index]
 }
 
-func (v solutionStopImpl) Previous() SolutionStop {
-	return v.solution.stopByIndexCache[v.solution.previous[v.index]]
-}
-
-func (v solutionStopImpl) previous() solutionStopImpl {
-	return solutionStopImpl{
+// Previous returns the previous stop the vehicle visited before the stop.
+// If the stop is the first stop of a vehicle, the solution stop itself is
+// returned. If the stop is unplanned, the previous stop has no semantic
+// meaning and the stop itself is returned.
+func (v SolutionStop) Previous() SolutionStop {
+	return SolutionStop{
 		index:    v.solution.previous[v.index],
 		solution: v.solution,
 	}
 }
 
-func (v solutionStopImpl) PreviousIndex() int {
+// PreviousIndex returns the index of the previous solution stop the
+// vehicle visited before the stop. If the stop is the first stop of a
+// vehicle, the index of the stop itself is returned. If the stop is
+// unplanned, the previous stop has no semantic meaning and the index of
+// the stop itself is returned.
+func (v SolutionStop) PreviousIndex() int {
 	return v.solution.previous[v.index]
 }
 
-func (v solutionStopImpl) ArrivalValue() float64 {
+// ArrivalValue returns the arrival time of the stop as a float64. If the
+// stop is unplanned, the arrival time has no semantic meaning.
+func (v SolutionStop) ArrivalValue() float64 {
 	return v.solution.arrival[v.index]
 }
 
-func (v solutionStopImpl) Arrival() time.Time {
+// Arrival returns the arrival time of the stop. If the stop is unplanned,
+// the arrival time has no semantic meaning.
+func (v SolutionStop) Arrival() time.Time {
 	if v.solution.next[v.index] != v.solution.previous[v.index] {
 		return v.solution.model.Epoch().
 			Add(
@@ -279,23 +171,35 @@ func (v solutionStopImpl) Arrival() time.Time {
 	return time.Time{}
 }
 
-func (v solutionStopImpl) Slack() time.Duration {
+// Slack returns the slack of the stop as a time.Duration. Slack is defined
+// as the duration you can start the invoking stop later without
+// postponing the last stop of the vehicle. If the stop is unplanned,
+// the slack has no semantic meaning. Slack is a consequence of the
+// earliest start of stops, if no earliest start is set, the slack is
+// always zero.
+func (v SolutionStop) Slack() time.Duration {
 	return time.Duration(v.SlackValue()) *
 		v.solution.model.DurationUnit()
 }
 
-func (v solutionStopImpl) SlackValue() float64 {
+// SlackValue returns the slack of the stop as a float64.
+func (v SolutionStop) SlackValue() float64 {
 	if v.solution.next[v.index] != v.solution.previous[v.index] {
 		return v.solution.slack[v.index]
 	}
 	return 0.0
 }
 
-func (v solutionStopImpl) StartValue() float64 {
+// StartValue returns the start time of the stop as a float64. If the stop
+// is unplanned, the start time has no semantic meaning. The returned
+// value is the number of Model.DurationUnit units since Model.Epoch.
+func (v SolutionStop) StartValue() float64 {
 	return v.solution.start[v.index]
 }
 
-func (v solutionStopImpl) Start() time.Time {
+// Start returns the start time of the stop. If the stop is unplanned, the
+// start time has no semantic meaning.
+func (v SolutionStop) Start() time.Time {
 	if v.solution.next[v.index] != v.solution.previous[v.index] {
 		return v.solution.model.Epoch().
 			Add(time.Duration(v.StartValue()) *
@@ -304,11 +208,16 @@ func (v solutionStopImpl) Start() time.Time {
 	return time.Time{}
 }
 
-func (v solutionStopImpl) EndValue() float64 {
+// EndValue returns the end time of the stop as a float64. If the stop is
+// unplanned, the end time has no semantic meaning. The returned value is
+// the number of Model.DurationUnit units since Model.Epoch.
+func (v SolutionStop) EndValue() float64 {
 	return v.solution.end[v.index]
 }
 
-func (v solutionStopImpl) End() time.Time {
+// End returns the end time of the stop. If the stop is unplanned, the end
+// time has no semantic meaning.
+func (v SolutionStop) End() time.Time {
 	if v.solution.next[v.index] != v.solution.previous[v.index] {
 		return v.solution.model.Epoch().
 			Add(time.Duration(v.EndValue()) *
@@ -317,86 +226,125 @@ func (v solutionStopImpl) End() time.Time {
 	return time.Time{}
 }
 
-func (v solutionStopImpl) DurationValue() float64 {
+// DurationValue returns the duration of the stop as a float64. If the stop
+// is unplanned, the duration has no semantic meaning.
+func (v SolutionStop) DurationValue() float64 {
 	return v.EndValue() - v.StartValue()
 }
 
-func (v solutionStopImpl) TravelDurationValue() float64 {
-	return v.CumulativeTravelDurationValue() - v.previous().CumulativeTravelDurationValue()
+// TravelDurationValue returns the travel duration of the stop as a
+// float64. If the stop is unplanned, the travel duration has no semantic
+// meaning. The travel duration is the time it takes to get to the
+// invoking stop. The returned value is the number of
+// Model.DurationUnit units.
+func (v SolutionStop) TravelDurationValue() float64 {
+	return v.CumulativeTravelDurationValue() - v.Previous().CumulativeTravelDurationValue()
 }
 
-func (v solutionStopImpl) TravelDuration() time.Duration {
+// TravelDuration returns the travel duration of the stop as a
+// time.Duration. If the stop is unplanned, the travel duration has no
+// semantic meaning. The travel duration is the time it takes to get to
+// the invoking stop.
+func (v SolutionStop) TravelDuration() time.Duration {
 	return time.Duration(v.TravelDurationValue()) *
 		v.solution.model.DurationUnit()
 }
 
-func (v solutionStopImpl) CumulativeTravelDurationValue() float64 {
+// CumulativeTravelDurationValue returns the cumulative travel duration of
+// the stop as a float64. The cumulative travel duration is the sum of the
+// travel durations of all stops that are visited before the stop. If the
+// stop is unplanned, the cumulative travel duration has no semantic
+// meaning. The returned value is the number of Model.DurationUnit units.
+func (v SolutionStop) CumulativeTravelDurationValue() float64 {
 	if v.solution.next[v.index] != v.solution.previous[v.index] {
 		return v.solution.cumulativeTravelDuration[v.index]
 	}
 	return 0
 }
 
-func (v solutionStopImpl) CumulativeTravelDuration() time.Duration {
+// CumulativeTravelDuration returns the cumulative value of the expression
+// for the stop as a time.Duration. The cumulative travel duration is the
+// sum of the travel durations of all stops that are visited before the
+// stop and the stop itself. If the stop is unplanned, the cumulative
+// travel duration has no semantic meaning.
+func (v SolutionStop) CumulativeTravelDuration() time.Duration {
 	return time.Duration(v.CumulativeTravelDurationValue()) *
 		v.solution.model.DurationUnit()
 }
 
-func (v solutionStopImpl) Vehicle() SolutionVehicle {
+// Vehicle returns the SolutionVehicle that visits the stop. If the stop
+// is unplanned, the vehicle has no semantic meaning and a panic will be
+// raised.
+func (v SolutionStop) Vehicle() SolutionVehicle {
 	if v.solution.next[v.index] == v.solution.previous[v.index] {
 		panic("cannot get route of unplanned visit")
 	}
 	return v.solution.solutionVehicles[v.solution.inVehicle[v.index]]
 }
 
-func (v solutionStopImpl) vehicle() solutionVehicleImpl {
+func (v SolutionStop) vehicle() solutionVehicleImpl {
 	return solutionVehicleImpl{
 		index:    v.solution.inVehicle[v.index],
 		solution: v.solution,
 	}
 }
 
-func (v solutionStopImpl) VehicleIndex() int {
+// VehicleIndex returns the index of the SolutionVehicle that visits the
+// stop. If the stop is unplanned, a panic will be raised.
+func (v SolutionStop) VehicleIndex() int {
 	if v.solution.next[v.index] == v.solution.previous[v.index] {
 		panic("cannot get route index of unplanned visit")
 	}
 	return v.solution.inVehicle[v.index]
 }
 
-func (v solutionStopImpl) Position() int {
+// Position returns the position of the stop in the vehicle starting with
+// 0 for the first stop. If the stop is unplanned, a panic will be raised.
+func (v SolutionStop) Position() int {
 	if v.solution.next[v.index] == v.solution.previous[v.index] {
 		panic("cannot get stop position of unplanned stop")
 	}
 	return v.solution.stopPosition[v.index]
 }
 
-func (v solutionStopImpl) IsFixed() bool {
+// IsFixed returns true if the stop is fixed. A fixed stop is a stop that
+// that can not transition form being planned to unplanned or vice versa.
+func (v SolutionStop) IsFixed() bool {
 	return v.ModelStop().IsFixed()
 }
 
-func (v solutionStopImpl) IsLast() bool {
+// IsLast returns true if the stop is the last stop of a vehicle.
+func (v SolutionStop) IsLast() bool {
 	return v.solution.next[v.index] == v.index &&
 		v.solution.previous[v.index] != v.index
 }
 
-func (v solutionStopImpl) IsFirst() bool {
+// IsFirst returns true if the stop is the first stop of a vehicle.
+func (v SolutionStop) IsFirst() bool {
 	return v.solution.previous[v.index] == v.index &&
 		v.solution.next[v.index] != v.index
 }
 
-func (v solutionStopImpl) ModelStop() ModelStop {
+// IsZero returns true if the stop is the zero value of SolutionStop.
+func (v SolutionStop) IsZero() bool {
+	return v.solution == nil && v.index == 0
+}
+
+// ModelStop returns the ModelStop that is the basis of the SolutionStop.
+func (v SolutionStop) ModelStop() ModelStop {
 	return v.solution.model.(*modelImpl).stops[v.solution.stop[v.index]]
 }
 
-func (v solutionStopImpl) modelStop() *stopImpl {
+func (v SolutionStop) modelStop() *stopImpl {
 	return v.solution.model.(*modelImpl).stops[v.solution.stop[v.index]].(*stopImpl)
 }
 
-func (v solutionStopImpl) ModelStopIndex() int {
+// ModelStopIndex is the index of the ModelStop in the Model.
+func (v SolutionStop) ModelStopIndex() int {
 	return v.solution.stop[v.index]
 }
 
-func (v solutionStopImpl) detach() {
+func (v SolutionStop) detach() {
 	previousIndex := v.solution.previous[v.index]
 	nextIndex := v.solution.next[v.index]
 
@@ -407,7 +355,7 @@ func (v solutionStopImpl) detach() {
 	v.solution.inVehicle[v.index] = -1
 }
 
-func (v solutionStopImpl) attach(after int) int {
+func (v SolutionStop) attach(after int) int {
 	v.solution.previous[v.index] = after
 	v.solution.next[v.index] = v.solution.next[after]
 

--- a/solution_stop_generator.go
+++ b/solution_stop_generator.go
@@ -44,7 +44,7 @@ func NewSolutionStopGenerator(
 		stopPositions:           slices.Clone(move.(*solutionMoveStopsImpl).stopPositions),
 		startAtFirst:            startAtFirst,
 		endAtLast:               endAtLast,
-		nextStop:                nextStop.(solutionStopImpl),
+		nextStop:                nextStop,
 		activeStopPositionIndex: 0,
 	}
 }
@@ -74,7 +74,7 @@ func newSolutionStopGenerator(
 }
 
 type solutionStopGeneratorImpl struct {
-	nextStop                solutionStopImpl
+	nextStop                SolutionStop
 	stopPositions           []StopPosition
 	activeStopPositionIndex int
 	startAtFirst            bool
@@ -85,7 +85,7 @@ type solutionStopGeneratorImpl struct {
 func (s *solutionStopGeneratorImpl) Next() SolutionStop {
 	next, ok := s.next()
 	if !ok {
-		return nil
+		return SolutionStop{}
 	}
 	return next
 }
@@ -94,9 +94,9 @@ func (s *solutionStopGeneratorImpl) release() {
 	solutionGeneratorPool.Put(s)
 }
 
-func (s *solutionStopGeneratorImpl) next() (solutionStopImpl, bool) {
+func (s *solutionStopGeneratorImpl) next() (SolutionStop, bool) {
 	if s.endReached {
-		return solutionStopImpl{}, false
+		return SolutionStop{}, false
 	}
 
 	returnStop := s.nextStop
@@ -106,7 +106,7 @@ func (s *solutionStopGeneratorImpl) next() (solutionStopImpl, bool) {
 			s.startAtFirst = false
 			s.nextStop = s.stopPositions[s.activeStopPositionIndex].stop()
 		} else {
-			s.nextStop = s.nextStop.next()
+			s.nextStop = s.nextStop.Next()
 		}
 		return returnStop, true
 	}
@@ -128,7 +128,7 @@ func (s *solutionStopGeneratorImpl) next() (solutionStopImpl, bool) {
 			if s.nextStop.IsLast() {
 				s.endReached = true
 			} else {
-				s.nextStop = s.nextStop.next()
+				s.nextStop = s.nextStop.Next()
 			}
 		}
 
@@ -145,7 +145,7 @@ func (s *solutionStopGeneratorImpl) next() (solutionStopImpl, bool) {
 			s.endReached = true
 			s.endAtLast = false
 		} else {
-			s.nextStop = s.nextStop.next()
+			s.nextStop = s.nextStop.Next()
 		}
 		return returnStop, true
 	}

--- a/solution_stop_generator_test.go
+++ b/solution_stop_generator_test.go
@@ -356,7 +356,7 @@ func BenchmarkSolutionStopGenerator(b *testing.B) {
 	sum := 0
 	for i := 0; i < b.N; i++ {
 		generator := nextroute.NewSolutionStopGenerator(move, true, true)
-		for solutionStop := generator.Next(); solutionStop != nil; solutionStop = generator.Next() {
+		for solutionStop := generator.Next(); !solutionStop.IsZero(); solutionStop = generator.Next() {
 			sum++
 		}
 	}
@@ -799,7 +799,7 @@ func testMove(
 
 	generator := nextroute.NewSolutionStopGenerator(move, startAtFirst, endAtLast)
 
-	for stop := generator.Next(); stop != nil; stop = generator.Next() {
+	for stop := generator.Next(); !stop.IsZero(); stop = generator.Next() {
 		if count == len(expected) {
 			t.Fatalf("too many stops, did not expect %v", stop)
 		}

--- a/solution_stop_position.go
+++ b/solution_stop_position.go
@@ -12,18 +12,9 @@ func NewStopPosition(
 	s SolutionStop,
 	n SolutionStop,
 ) (StopPosition, error) {
-	if p == nil {
-		return StopPosition{}, fmt.Errorf("previous stop is nil")
-	}
-	if s == nil {
-		return StopPosition{}, fmt.Errorf("stop is nil")
-	}
-	if n == nil {
-		return StopPosition{}, fmt.Errorf("next stop is nil")
-	}
-	previous := p.(solutionStopImpl)
-	stop := s.(solutionStopImpl)
-	next := n.(solutionStopImpl)
+	previous := p
+	stop := s
+	next := n
 	if previous.Solution() != stop.Solution() {
 		return StopPosition{}, fmt.Errorf(
 			"previous %v and stop %v are on different solutions",
@@ -62,9 +53,9 @@ func NewStopPosition(
 }
 
 func newStopPosition(
-	previous solutionStopImpl,
-	stop solutionStopImpl,
-	next solutionStopImpl,
+	previous SolutionStop,
+	stop SolutionStop,
+	next SolutionStop,
 ) StopPosition {
 	return StopPosition{
 		previousStopIndex: previous.index,
@@ -89,39 +80,39 @@ func (v StopPosition) String() string {
 // involving the stop position is executed. It's worth noting that
 // the previous stop may not have been planned yet.
 func (v StopPosition) Previous() SolutionStop {
-	return v.solution.stopByIndexCache[v.previousStopIndex]
+	return v.previous()
 }
 
 // Next denotes the upcoming stop's next stop if the associated move
 // involving the stop position is executed. It's worth noting that
 // the next stop may not have been planned yet.
 func (v StopPosition) Next() SolutionStop {
-	return v.solution.stopByIndexCache[v.nextStopIndex]
+	return v.next()
 }
 
 // Stop returns the stop which is not yet part of the solution. This stop
 // is not planned yet if the move where the invoking stop position belongs
 // to, has not been executed yet.
 func (v StopPosition) Stop() SolutionStop {
-	return v.solution.stopByIndexCache[v.stopIndex]
+	return v.stop()
 }
 
-func (v StopPosition) previous() solutionStopImpl {
-	return solutionStopImpl{
+func (v StopPosition) previous() SolutionStop {
+	return SolutionStop{
 		index:    v.previousStopIndex,
 		solution: v.solution,
 	}
 }
 
-func (v StopPosition) next() solutionStopImpl {
-	return solutionStopImpl{
+func (v StopPosition) next() SolutionStop {
+	return SolutionStop{
 		index:    v.nextStopIndex,
 		solution: v.solution,
 	}
 }
 
-func (v StopPosition) stop() solutionStopImpl {
-	return solutionStopImpl{
+func (v StopPosition) stop() SolutionStop {
+	return SolutionStop{
 		index:    v.stopIndex,
 		solution: v.solution,
 	}

--- a/solution_vehicle.go
+++ b/solution_vehicle.go
@@ -261,9 +261,9 @@ func (v solutionVehicleImpl) bestMovePlanSingleStop(
 	rand := solution.random
 
 	for !stop.IsLast() {
-		stop = stop.next()
+		stop = stop.Next()
 		pos := newStopPosition(
-			stop.previous(),
+			stop.Previous(),
 			candidateStop,
 			stop,
 		)
@@ -550,15 +550,15 @@ func (v solutionVehicleImpl) Last() SolutionStop {
 	return v.last()
 }
 
-func (v solutionVehicleImpl) first() solutionStopImpl {
-	return solutionStopImpl{
+func (v solutionVehicleImpl) first() SolutionStop {
+	return SolutionStop{
 		index:    v.solution.first[v.index],
 		solution: v.solution,
 	}
 }
 
-func (v solutionVehicleImpl) last() solutionStopImpl {
-	return solutionStopImpl{
+func (v solutionVehicleImpl) last() SolutionStop {
+	return SolutionStop{
 		index:    v.solution.last[v.index],
 		solution: v.solution,
 	}
@@ -589,7 +589,7 @@ func (v solutionVehicleImpl) End() time.Time {
 }
 
 func (v solutionVehicleImpl) Next() SolutionStop {
-	return solutionStopImpl{
+	return SolutionStop{
 		index:    v.solution.model.NumberOfStops() + v.index*2 + 1,
 		solution: v.solution,
 	}
@@ -606,12 +606,12 @@ func (v solutionVehicleImpl) SolutionStops() SolutionStops {
 	return solutionStops
 }
 
-func (v solutionVehicleImpl) solutionStops() []solutionStopImpl {
-	solutionStops := make([]solutionStopImpl, 0, v.NumberOfStops()+2)
+func (v solutionVehicleImpl) solutionStops() []SolutionStop {
+	solutionStops := make([]SolutionStop, 0, v.NumberOfStops()+2)
 	solutionStop := v.first()
 	for !solutionStop.IsLast() {
 		solutionStops = append(solutionStops, solutionStop)
-		solutionStop = solutionStop.next()
+		solutionStop = solutionStop.Next()
 	}
 	solutionStops = append(solutionStops, solutionStop)
 	return solutionStops
@@ -623,7 +623,7 @@ func (v solutionVehicleImpl) ModelVehicle() ModelVehicle {
 
 func (v solutionVehicleImpl) Unplan() (bool, error) {
 	// TODO notify observers
-	solutionStops := common.Filter(v.solutionStops(), func(solutionStop solutionStopImpl) bool {
+	solutionStops := common.Filter(v.solutionStops(), func(solutionStop SolutionStop) bool {
 		return !solutionStop.IsFixed()
 	})
 	if len(solutionStops) == 0 {
@@ -632,18 +632,18 @@ func (v solutionVehicleImpl) Unplan() (bool, error) {
 
 	solution := solutionStops[0].solution
 
-	planUnits := common.Map(solutionStops, func(solutionStop solutionStopImpl) *solutionPlanStopsUnitImpl {
+	planUnits := common.Map(solutionStops, func(solutionStop SolutionStop) *solutionPlanStopsUnitImpl {
 		return solutionStop.planStopsUnit()
 	})
 	for _, planUnit := range planUnits {
 		solution.unPlannedPlanUnits.add(planUnit)
 		solution.plannedPlanUnits.remove(planUnit)
 	}
-	stopPositions := common.Map(solutionStops, func(solutionStop solutionStopImpl) StopPosition {
+	stopPositions := common.Map(solutionStops, func(solutionStop SolutionStop) StopPosition {
 		return newStopPosition(
-			solutionStop.previous(),
+			solutionStop.Previous(),
 			solutionStop,
-			solutionStop.next(),
+			solutionStop.Next(),
 		)
 	})
 

--- a/solve_operator_unplan.go
+++ b/solve_operator_unplan.go
@@ -247,15 +247,15 @@ func (d *solveOperatorUnPlanImpl) unplanLocation(
 	for _, plannedPlanStopsUnit := range plannedPlanStopsUnits {
 		for _, solutionStop := range plannedPlanStopsUnit.(*solutionPlanStopsUnitImpl).solutionStops {
 			location := solutionStop.ModelStop().Location()
-			stop := solutionStop.next()
+			stop := solutionStop.Next()
 			for location.Equals(stop.ModelStop().Location()) && !stop.IsLast() {
 				unPlanUnits = append(unPlanUnits, stop.PlanStopsUnit())
-				stop = stop.next()
+				stop = stop.Next()
 			}
-			stop = solutionStop.previous()
+			stop = solutionStop.Previous()
 			for location.Equals(stop.ModelStop().Location()) && !stop.IsFirst() {
 				unPlanUnits = append(unPlanUnits, stop.PlanStopsUnit())
-				stop = stop.previous()
+				stop = stop.Previous()
 			}
 		}
 	}

--- a/solve_operator_unplan_location.go
+++ b/solve_operator_unplan_location.go
@@ -40,15 +40,15 @@ func (d *solveOperatorUnPlanLocationImpl) unplanLocation(
 	for _, plannedPlanStopsUnit := range plannedPlanStopsUnits {
 		for _, solutionStop := range plannedPlanStopsUnit.(*solutionPlanStopsUnitImpl).solutionStops {
 			location := solutionStop.ModelStop().Location()
-			stop := solutionStop.next()
+			stop := solutionStop.Next()
 			for location.Equals(stop.ModelStop().Location()) && !stop.IsLast() {
 				unPlanUnits = append(unPlanUnits, stop.PlanStopsUnit())
-				stop = stop.next()
+				stop = stop.Next()
 			}
-			stop = solutionStop.previous()
+			stop = solutionStop.Previous()
 			for location.Equals(stop.ModelStop().Location()) && !stop.IsFirst() {
 				unPlanUnits = append(unPlanUnits, stop.PlanStopsUnit())
-				stop = stop.previous()
+				stop = stop.Previous()
 			}
 		}
 	}


### PR DESCRIPTION
This PR turns the SolutionStop interface into a struct. It also adds an `IsZero()` function to it to have a standard way to decide if it's a Zero-value. This can be used in places where we previously checked for `nil`.

So far all benchmarks look very promising.