### PR TITLE
Reduce allocations on length check

### DIFF
--- a/solution_move_units.go
+++ b/solution_move_units.go
@@ -11,11 +11,11 @@ func newSolutionMoveUnits(
 	planUnit *solutionPlanUnitsUnitImpl,
 	moves SolutionMoves,
 ) solutionMoveUnitsImpl {
-	if len(moves) != len(planUnit.SolutionPlanUnits()) {
+	if len(moves) != len(planUnit.solutionPlanUnits) {
 		panic(
 			fmt.Sprintf("moves and SolutionPlanUnits must have the same length: %v != %v",
 				len(moves),
-				len(planUnit.SolutionPlanUnits()),
+				len(planUnit.solutionPlanUnits),
 			),
 		)
 	}


### PR DESCRIPTION
We accidentally cloned a slice when checking for its length.

```
name                                old time/op    new time/op    delta
Golden/testdata/stop_groups.json-8     306µs ± 5%     305µs ± 7%    ~     (p=0.780 n=9+10)

name                                old alloc/op   new alloc/op   delta
Golden/testdata/stop_groups.json-8     489kB ± 3%     476kB ± 3%  -2.76%  (p=0.000 n=9+9)

name                                old allocs/op  new allocs/op  delta
Golden/testdata/stop_groups.json-8     8.77k ± 2%     8.39k ± 4%  -4.34%  (p=0.000 n=8+9)
```