### PR TITLE
Minor performance improvements

### DIFF
--- a/model_expression_duration.go
+++ b/model_expression_duration.go
@@ -262,9 +262,7 @@ func (s *stopDurationExpressionImpl) Value(
 	_ ModelStop,
 	stop ModelStop,
 ) float64 {
-	index := stop.Index()
-
-	if value, ok := s.values[index]; ok {
+	if value, ok := s.values[stop.Index()]; ok {
 		return value
 	}
 	return s.defaultValue
@@ -347,9 +345,7 @@ func (v *vehicleTypeDurationExpressionImpl) Value(
 	_ ModelStop,
 	_ ModelStop,
 ) float64 {
-	index := vehicleType.Index()
-
-	if value, ok := v.values[index]; ok {
+	if value, ok := v.values[vehicleType.Index()]; ok {
 		return value
 	}
 	return v.defaultValue

--- a/solution_move_units.go
+++ b/solution_move_units.go
@@ -40,7 +40,6 @@ func newNotExecutableSolutionMoveUnits(planUnit *solutionPlanUnitsUnitImpl) *sol
 		solution:  planUnit.Solution().(*solutionImpl),
 		planUnit:  planUnit,
 		valueSeen: 1,
-		allowed:   false,
 	}
 }
 

--- a/solution_unplan.go
+++ b/solution_unplan.go
@@ -28,13 +28,15 @@ func UnplanIsland(
 			stop = stop.Previous()
 		}
 		if distance.Value(common.Meters) > 0 {
-			closestStops, err := solutionStop.ModelStop().ClosestStops()
+			closestStops, err := solutionStop.modelStop().closestStops()
 			if err != nil {
 				return err
 			}
 			for _, closeModelStop := range closestStops {
-				if haversineDistance(solutionStop.ModelStop().Location(), closeModelStop.Location()).Value(common.Meters) <=
-					distance.Value(common.Meters) {
+				d := haversineDistance(
+					solutionStop.ModelStop().Location(),
+					closeModelStop.Location()).Value(common.Meters)
+				if d <= distance.Value(common.Meters) {
 					unplanUnits = append(unplanUnits, solutionStop.PlanStopsUnit())
 					break
 				}


### PR DESCRIPTION
Just some smaller changes that I noticed while looking at `go build -gcflags='-m=1'` output.

It slightly increases mean #iterations by about 1%.