### PR TITLE
Adds support for Python 3.13

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: git clone
         uses: actions/checkout@v4

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         platform: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - name: git clone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "pydantic>=2.5.2",
@@ -71,7 +72,7 @@ nextroute = ["bin/*.exe"]
 
 [tool.cibuildwheel]
 test-command = 'python -c "exec(\"import nextroute\nprint(nextroute.nextroute_version())\")"'
-build = "cp3{8,9,10,11,12}-*"
+build = "cp3{8,9,10,11,12,13}-*"
 skip = "*musllinux*"
 archs = "native"
 manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"


### PR DESCRIPTION
# Description

This update extends support to Python 3.13, ensuring compatibility with the latest Python version.

## Changes

- Updated Python version matrix in `.github/workflows/python-lint.yml` to include 3.13
- Updated Python version matrix in `.github/workflows/python-test.yml` to include 3.13
- Updated build versions in `pyproject.toml` to include Python 3.13