### PR TITLE
Enhance model validation with maximum time horizon check

### DIFF
--- a/factory/model.go
+++ b/factory/model.go
@@ -46,7 +46,7 @@ type Options struct {
 			DurationGroups          bool `json:"duration_groups" usage:"ignore the durations groups of stops"`
 			InitialSolution         bool `json:"initial_solution" usage:"ignore the initial solution"`
 		} `json:"disable"`
-		MaximumTimeHorizon int `json:"maximum_time_horizon" usage:"maximum time horizon for the model in seconds" default:"604800"`
+		MaximumTimeHorizon int `json:"maximum_time_horizon" usage:"maximum time horizon for the model in seconds" default:"2592000"`
 	} `json:"properties"`
 	Validate struct {
 		Disable struct {

--- a/factory/model.go
+++ b/factory/model.go
@@ -46,6 +46,7 @@ type Options struct {
 			DurationGroups          bool `json:"duration_groups" usage:"ignore the durations groups of stops"`
 			InitialSolution         bool `json:"initial_solution" usage:"ignore the initial solution"`
 		} `json:"disable"`
+		MaximumTimeHorizon int `json:"maximum_time_horizon" usage:"maximum time horizon for the model in seconds" default:"604800"`
 	} `json:"properties"`
 	Validate struct {
 		Disable struct {

--- a/factory/validate.go
+++ b/factory/validate.go
@@ -1250,7 +1250,7 @@ func validateTimeHorizon(input schema.Input, modelOptions Options) error {
 	if int(maxTime.Sub(minTime).Seconds()) > modelOptions.Properties.MaximumTimeHorizon {
 		return nmerror.NewInputDataError(fmt.Errorf(
 			"the time horizon of the input data is %v, which is larger than the configured maximum allowed time horizon of %v"+
-				" - please adjust the maximum time horizon if intentional",
+				" - please adjust the maximum time horizon via options if intentional",
 			maxTime.Sub(minTime),
 			time.Duration(modelOptions.Properties.MaximumTimeHorizon)*time.Second,
 		))

--- a/factory/validate.go
+++ b/factory/validate.go
@@ -1254,7 +1254,8 @@ func validateTimeHorizon(input schema.Input, modelOptions Options) error {
 
 	if int(maxTime.Sub(minTime).Seconds()) > modelOptions.Properties.MaximumTimeHorizon {
 		return nmerror.NewInputDataError(fmt.Errorf(
-			"the time horizon of the input data is %v, which is larger than the maximum allowed time horizon of %v",
+			"the time horizon of the input data is %v, which is larger than the configured maximum allowed time horizon of %v"+
+				" - please adjust the maximum time horizon if intentional",
 			maxTime.Sub(minTime),
 			time.Duration(modelOptions.Properties.MaximumTimeHorizon)*time.Second,
 		))

--- a/factory/validate.go
+++ b/factory/validate.go
@@ -80,7 +80,10 @@ func validate(input schema.Input, modelOptions Options) error {
 	if err := validateResources(input, modelOptions); err != nil {
 		return err
 	}
-	return validateConstraints(input, modelOptions)
+	if err := validateConstraints(input, modelOptions); err != nil {
+		return err
+	}
+	return validateTimeHorizon(input, modelOptions)
 }
 
 func identify(input schema.Input, i int) string {
@@ -1175,4 +1178,87 @@ func convertToTimeDependentMatrix(data map[string]any) (schema.TimeDependentMatr
 	}
 
 	return result, nil
+}
+
+// validateTimeHorizon validates that the overall time horizon of the input data
+// is within the maximum allowed range.
+func validateTimeHorizon(input schema.Input, modelOptions Options) error {
+	if modelOptions.Properties.MaximumTimeHorizon <= 0 {
+		// Ignore time horizon validation on user request
+		return nil
+	}
+
+	// Keep track of minimum and maximum time in the input data
+	minTime := time.Time{}                             // zero time
+	maxTime := time.Unix(1<<63-62135596801, 999999999) // max time
+
+	// Define some helper functions
+	updateMinMaxTime := func(t time.Time) {
+		if t.Before(minTime) {
+			minTime = t
+		}
+		if t.After(maxTime) {
+			maxTime = t
+		}
+	}
+	updateMinMaxWindows := func(timeWindows [][2]time.Time) {
+		for _, tw := range timeWindows {
+			for _, t := range tw {
+				if t.IsZero() {
+					continue
+				}
+				if t.Before(minTime) {
+					minTime = t
+				}
+				if t.After(maxTime) {
+					maxTime = t
+				}
+			}
+		}
+	}
+
+	for _, vehicle := range input.Vehicles {
+		if vehicle.StartTime != nil {
+			updateMinMaxTime(*vehicle.StartTime)
+		}
+		if vehicle.EndTime != nil {
+			updateMinMaxTime(*vehicle.EndTime)
+		}
+	}
+
+	for _, stop := range input.Stops {
+		if stop.StartTimeWindow != nil {
+			timeWindows, err := convertTimeWindow(stop.StartTimeWindow, stop.ID)
+			if err != nil {
+				return err
+			}
+
+			updateMinMaxWindows(timeWindows)
+		}
+	}
+
+	if input.AlternateStops != nil {
+		for _, stop := range *input.AlternateStops {
+			if stop.StartTimeWindow == nil {
+				continue
+			}
+
+			timeWindows, err := convertTimeWindow(stop.StartTimeWindow, stop.ID)
+			if err != nil {
+				return err
+			}
+
+			updateMinMaxWindows(timeWindows)
+		}
+	}
+
+	if int(maxTime.Sub(minTime).Seconds()) > modelOptions.Properties.MaximumTimeHorizon {
+		return nmerror.NewInputDataError(fmt.Errorf(
+			"the time horizon of the input data is %v, which is larger than the maximum allowed time horizon of %v",
+			maxTime.Sub(minTime),
+			time.Duration(modelOptions.Properties.MaximumTimeHorizon)*time.Second,
+		))
+	}
+
+	return nil
 }

--- a/factory/validate.go
+++ b/factory/validate.go
@@ -1189,8 +1189,8 @@ func validateTimeHorizon(input schema.Input, modelOptions Options) error {
 	}
 
 	// Keep track of minimum and maximum time in the input data
-	minTime := time.Time{}                             // zero time
-	maxTime := time.Unix(1<<63-62135596801, 999999999) // max time
+	minTime := time.Unix(1<<63-62135596801, 999999999) // zero time
+	maxTime := time.Time{}                             // max time
 
 	// Define some helper functions
 	updateMinMaxTime := func(t time.Time) {
@@ -1207,12 +1207,7 @@ func validateTimeHorizon(input schema.Input, modelOptions Options) error {
 				if t.IsZero() {
 					continue
 				}
-				if t.Before(minTime) {
-					minTime = t
-				}
-				if t.After(maxTime) {
-					maxTime = t
-				}
+				updateMinMaxTime(t)
 			}
 		}
 	}

--- a/tests/check/input.json.golden
+++ b/tests/check/input.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/check/input.json.golden
+++ b/tests/check/input.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/custom_constraint/input.json.golden
+++ b/tests/custom_constraint/input.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/custom_constraint/input.json.golden
+++ b/tests/custom_constraint/input.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/custom_matrices/input.json.golden
+++ b/tests/custom_matrices/input.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/custom_matrices/input.json.golden
+++ b/tests/custom_matrices/input.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/custom_objective/input.json.golden
+++ b/tests/custom_objective/input.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/custom_objective/input.json.golden
+++ b/tests/custom_objective/input.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/custom_operators/input.json.golden
+++ b/tests/custom_operators/input.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/custom_operators/input.json.golden
+++ b/tests/custom_operators/input.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/activation_penalty.json.golden
+++ b/tests/golden/testdata/activation_penalty.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/activation_penalty.json.golden
+++ b/tests/golden/testdata/activation_penalty.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/alternates.json.golden
+++ b/tests/golden/testdata/alternates.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/alternates.json.golden
+++ b/tests/golden/testdata/alternates.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/basic.json.golden
+++ b/tests/golden/testdata/basic.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/basic.json.golden
+++ b/tests/golden/testdata/basic.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/capacity.json.golden
+++ b/tests/golden/testdata/capacity.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/capacity.json.golden
+++ b/tests/golden/testdata/capacity.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/compatibility_attributes.json.golden
+++ b/tests/golden/testdata/compatibility_attributes.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/compatibility_attributes.json.golden
+++ b/tests/golden/testdata/compatibility_attributes.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/complex_precedence.json.golden
+++ b/tests/golden/testdata/complex_precedence.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/complex_precedence.json.golden
+++ b/tests/golden/testdata/complex_precedence.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/custom_data.json.golden
+++ b/tests/golden/testdata/custom_data.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/custom_data.json.golden
+++ b/tests/golden/testdata/custom_data.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/defaults.json.golden
+++ b/tests/golden/testdata/defaults.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/defaults.json.golden
+++ b/tests/golden/testdata/defaults.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/direct_precedence.json.golden
+++ b/tests/golden/testdata/direct_precedence.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/direct_precedence.json.golden
+++ b/tests/golden/testdata/direct_precedence.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/direct_precedence_linked.json.golden
+++ b/tests/golden/testdata/direct_precedence_linked.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/direct_precedence_linked.json.golden
+++ b/tests/golden/testdata/direct_precedence_linked.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/distance_matrix.json.golden
+++ b/tests/golden/testdata/distance_matrix.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/distance_matrix.json.golden
+++ b/tests/golden/testdata/distance_matrix.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_groups.json.golden
+++ b/tests/golden/testdata/duration_groups.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_groups.json.golden
+++ b/tests/golden/testdata/duration_groups.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_groups_with_stop_multiplier.json.golden
+++ b/tests/golden/testdata/duration_groups_with_stop_multiplier.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_groups_with_stop_multiplier.json.golden
+++ b/tests/golden/testdata/duration_groups_with_stop_multiplier.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_matrix.json.golden
+++ b/tests/golden/testdata/duration_matrix.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_matrix.json.golden
+++ b/tests/golden/testdata/duration_matrix.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_matrix_time_dependent0.json.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent0.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_matrix_time_dependent0.json.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent0.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_matrix_time_dependent1.json.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent1.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_matrix_time_dependent1.json.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent1.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_matrix_time_dependent2.json.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent2.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_matrix_time_dependent2.json.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent2.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_matrix_time_dependent3.json.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent3.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/duration_matrix_time_dependent3.json.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent3.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/early_arrival_penalty.json.golden
+++ b/tests/golden/testdata/early_arrival_penalty.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/early_arrival_penalty.json.golden
+++ b/tests/golden/testdata/early_arrival_penalty.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops.json.golden
+++ b/tests/golden/testdata/initial_stops.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops.json.golden
+++ b/tests/golden/testdata/initial_stops.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops_infeasible_compatibility.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_compatibility.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops_infeasible_compatibility.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_compatibility.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops_infeasible_max_duration.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_max_duration.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops_infeasible_max_duration.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_max_duration.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops_infeasible_remove_all.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_remove_all.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops_infeasible_remove_all.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_remove_all.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops_infeasible_temporal.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_temporal.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops_infeasible_temporal.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_temporal.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops_infeasible_tuple.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_tuple.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/initial_stops_infeasible_tuple.json.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_tuple.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/late_arrival_penalty.json.golden
+++ b/tests/golden/testdata/late_arrival_penalty.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/late_arrival_penalty.json.golden
+++ b/tests/golden/testdata/late_arrival_penalty.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/max_distance.json.golden
+++ b/tests/golden/testdata/max_distance.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {
@@ -76,10 +77,10 @@
         "name": "1 * vehicles_duration + 1 * unplanned_penalty",
         "objectives": [
           {
-            "base": 148.90959499292012,
+            "base": 148.9095949929201,
             "factor": 1,
             "name": "vehicles_duration",
-            "value": 148.90959499292012
+            "value": 148.9095949929201
           },
           {
             "base": 6000000,

--- a/tests/golden/testdata/max_distance.json.golden
+++ b/tests/golden/testdata/max_distance.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/max_duration.json.golden
+++ b/tests/golden/testdata/max_duration.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/max_duration.json.golden
+++ b/tests/golden/testdata/max_duration.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/max_stops.json.golden
+++ b/tests/golden/testdata/max_stops.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/max_stops.json.golden
+++ b/tests/golden/testdata/max_stops.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/max_wait_stop.json.golden
+++ b/tests/golden/testdata/max_wait_stop.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/max_wait_stop.json.golden
+++ b/tests/golden/testdata/max_wait_stop.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/max_wait_vehicle.json.golden
+++ b/tests/golden/testdata/max_wait_vehicle.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/max_wait_vehicle.json.golden
+++ b/tests/golden/testdata/max_wait_vehicle.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/min_stops.json.golden
+++ b/tests/golden/testdata/min_stops.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/min_stops.json.golden
+++ b/tests/golden/testdata/min_stops.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {
@@ -76,10 +77,10 @@
         "name": "1 * vehicles_duration + 1 * unplanned_penalty + 1 * min_stops",
         "objectives": [
           {
-            "base": 909.0466359667603,
+            "base": 909.04663596676,
             "factor": 1,
             "name": "vehicles_duration",
-            "value": 909.0466359667603
+            "value": 909.04663596676
           },
           {
             "factor": 1,
@@ -92,7 +93,7 @@
             "value": 0
           }
         ],
-        "value": 909.0466359667603
+        "value": 909.04663596676
       },
       "unplanned": [],
       "vehicles": [

--- a/tests/golden/testdata/multi_window.json.golden
+++ b/tests/golden/testdata/multi_window.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/multi_window.json.golden
+++ b/tests/golden/testdata/multi_window.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/no_mix.json.golden
+++ b/tests/golden/testdata/no_mix.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/no_mix.json.golden
+++ b/tests/golden/testdata/no_mix.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/no_mix_null.json.golden
+++ b/tests/golden/testdata/no_mix_null.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/no_mix_null.json.golden
+++ b/tests/golden/testdata/no_mix_null.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/precedence.json.golden
+++ b/tests/golden/testdata/precedence.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/precedence.json.golden
+++ b/tests/golden/testdata/precedence.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/precedence_pathologic.json.golden
+++ b/tests/golden/testdata/precedence_pathologic.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/precedence_pathologic.json.golden
+++ b/tests/golden/testdata/precedence_pathologic.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/start_level.json.golden
+++ b/tests/golden/testdata/start_level.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/start_level.json.golden
+++ b/tests/golden/testdata/start_level.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/start_time_window.json.golden
+++ b/tests/golden/testdata/start_time_window.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/start_time_window.json.golden
+++ b/tests/golden/testdata/start_time_window.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/stop_duration.json.golden
+++ b/tests/golden/testdata/stop_duration.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/stop_duration.json.golden
+++ b/tests/golden/testdata/stop_duration.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/stop_duration_multiplier.json.golden
+++ b/tests/golden/testdata/stop_duration_multiplier.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/stop_duration_multiplier.json.golden
+++ b/tests/golden/testdata/stop_duration_multiplier.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/stop_groups.json.golden
+++ b/tests/golden/testdata/stop_groups.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/stop_groups.json.golden
+++ b/tests/golden/testdata/stop_groups.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/template_input.json.golden
+++ b/tests/golden/testdata/template_input.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/template_input.json.golden
+++ b/tests/golden/testdata/template_input.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/unplanned_penalty.json.golden
+++ b/tests/golden/testdata/unplanned_penalty.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/unplanned_penalty.json.golden
+++ b/tests/golden/testdata/unplanned_penalty.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/vehicle_start_end_location.json.golden
+++ b/tests/golden/testdata/vehicle_start_end_location.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/vehicle_start_end_location.json.golden
+++ b/tests/golden/testdata/vehicle_start_end_location.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {
@@ -76,10 +77,10 @@
         "name": "1 * vehicles_duration + 1 * unplanned_penalty",
         "objectives": [
           {
-            "base": 375.4720230604402,
+            "base": 375.47202306044016,
             "factor": 1,
             "name": "vehicles_duration",
-            "value": 375.4720230604402
+            "value": 375.47202306044016
           },
           {
             "factor": 1,
@@ -87,7 +88,7 @@
             "value": 0
           }
         ],
-        "value": 375.4720230604402
+        "value": 375.47202306044016
       },
       "unplanned": [],
       "vehicles": [

--- a/tests/golden/testdata/vehicle_start_end_time.json.golden
+++ b/tests/golden/testdata/vehicle_start_end_time.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/vehicle_start_end_time.json.golden
+++ b/tests/golden/testdata/vehicle_start_end_time.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/vehicles_duration_objective.json.golden
+++ b/tests/golden/testdata/vehicles_duration_objective.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/golden/testdata/vehicles_duration_objective.json.golden
+++ b/tests/golden/testdata/vehicles_duration_objective.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/inline_options/input.json.golden
+++ b/tests/inline_options/input.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/inline_options/input.json.golden
+++ b/tests/inline_options/input.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {

--- a/tests/output_options/main.sh.golden
+++ b/tests/output_options/main.sh.golden
@@ -40,7 +40,7 @@
         "duration_groups": false,
         "initial_solution": false
       },
-      "maximum_time_horizon": 604800
+      "maximum_time_horizon": 2592000
     },
     "validate": {
       "disable": {

--- a/tests/output_options/main.sh.golden
+++ b/tests/output_options/main.sh.golden
@@ -39,7 +39,8 @@
         "stop_duration_multipliers": false,
         "duration_groups": false,
         "initial_solution": false
-      }
+      },
+      "maximum_time_horizon": 604800
     },
     "validate": {
       "disable": {

--- a/tests/stop_balancing_objective/input.json.golden
+++ b/tests/stop_balancing_objective/input.json.golden
@@ -50,7 +50,7 @@
           "initial_solution": false,
           "stop_duration_multipliers": false
         },
-        "maximum_time_horizon": 604800
+        "maximum_time_horizon": 2592000
       },
       "validate": {
         "disable": {

--- a/tests/stop_balancing_objective/input.json.golden
+++ b/tests/stop_balancing_objective/input.json.golden
@@ -49,7 +49,8 @@
           "durations": false,
           "initial_solution": false,
           "stop_duration_multipliers": false
-        }
+        },
+        "maximum_time_horizon": 604800
       },
       "validate": {
         "disable": {


### PR DESCRIPTION
# Description

> [!WARNING]  
> The check for maximum time horizon is technically breaking. The default configured maximum of **1 month (30 days)** should not reject any inputs, as the validation only means to detect erroneous inputs.
> However, if you are using nextroute for inputs > 1 month planning horizon, we urge you to configure `-model.properties.maximumtimehorizon` (given in `int` seconds) to a sufficiently large value. E.g., set it to `5184000` (_60 * 24 * 60 * 60_), if planning in a 60 day time horizon.

> [!IMPORTANT]  
> The limit was bumped to _6 months_ in a follow-up PR to mitigate impact on existing use-cases (#79 ).

Introduced a new option to specify a maximum time horizon for models and added validation to ensure the input data adheres to this constraint.

## Changes

- Added `MaximumTimeHorizon` option in `model.go` to specify the maximum time horizon for the model.
  - Configure via the `-model.properties.maximumtimehorizon` option.
  - Value expected in _seconds_.
  - Default value is `2592000`s / 30 days.
- Implemented `validateTimeHorizon` function in `validate.go` to check if the input data's time horizon exceeds the specified maximum.
- Modified `validate` function to include the time horizon validation step.