### PR TITLE
Avoids running auto-benchmark on tag pushes

### DIFF
--- a/.github/workflows/auto-benchmark.yml
+++ b/.github/workflows/auto-benchmark.yml
@@ -1,5 +1,8 @@
 name: auto benchmark
-on: [push]
+on:
+  push:
+    branches:
+      - "*"
 
 env:
   GO_VERSION: 1.23

--- a/.github/workflows/auto-benchmark.yml
+++ b/.github/workflows/auto-benchmark.yml
@@ -2,7 +2,7 @@ name: auto benchmark
 on:
   push:
     branches:
-      - "*"
+      - "**"
 
 env:
   GO_VERSION: 1.23


### PR DESCRIPTION
# Description

Fixes the triggers for the auto-benchmark workflow to only run on branch pushes (avoiding tag pushes), since we are only interested tracking performance for code changes.

## Changes

- Modified the trigger event in `auto-benchmark.yml` to run on push events only for branches.