### PR TITLE
Fixes an issue in plateau detection

### DIFF
--- a/solve_solver.go
+++ b/solve_solver.go
@@ -35,6 +35,10 @@ type SolverOptions struct {
 // either the Duration or Iterations condition is met, depending on which occurs
 // first.
 type PlateauOptions struct {
+	// Delay is the delay before plateau detection starts. This is useful to
+	// avoid stopping the solver too early, e.g., when the solver is still
+	// finding the first feasible solution. Default: 0s (no delay).
+	Delay time.Duration `json:"delay"  usage:"delay before plateau detection starts" default:"0s"`
 	// Duration is the maximum duration without (significant) improvement. I.e.,
 	// if the solver does not improve the best solution (significantly) within
 	// this duration, the solver will stop. A duration of 0 means that the

--- a/solve_terminate.go
+++ b/solve_terminate.go
@@ -63,9 +63,9 @@ func (t *plateauTracker) ShouldTerminate(iterations int, elapsed time.Duration) 
 
 	// Check if no significantly improving solutions were found during the
 	// configured duration.
-	if t.options.Duration > 0 {
-		cutoffSeconds := t.options.Duration.Seconds()
-		elapsedSeconds := elapsed.Seconds()
+	cutoffSeconds := t.options.Duration.Seconds()
+	elapsedSeconds := elapsed.Seconds()
+	if cutoffSeconds > 0 && elapsedSeconds >= cutoffSeconds {
 		// Move the duration index to the first entry within the cutoff.
 		for t.durationIndex < len(t.progression) &&
 			(elapsedSeconds-t.progression[t.durationIndex].ElapsedSeconds) > cutoffSeconds {
@@ -94,7 +94,7 @@ func (t *plateauTracker) ShouldTerminate(iterations int, elapsed time.Duration) 
 
 	// Check if no significantly improving solutions were found during the
 	// configured iterations.
-	if t.options.Iterations > 0 {
+	if t.options.Iterations > 0 && iterations >= t.options.Iterations {
 		// Move the iterations index to the first entry within the cutoff.
 		for t.iterationsIndex < len(t.progression) &&
 			iterations-t.progression[t.iterationsIndex].Iterations > t.options.Iterations {

--- a/solve_terminate.go
+++ b/solve_terminate.go
@@ -61,6 +61,13 @@ func (t *plateauTracker) ShouldTerminate(iterations int, elapsed time.Duration) 
 
 	currentValue := t.progression[len(t.progression)-1].Value
 
+	return t.shouldTerminateDuration(currentValue, elapsed) ||
+		t.shouldTerminateIterations(currentValue, iterations)
+}
+
+// shouldTerminateDuration returns true if the solver should terminate due to a
+// temporal plateau.
+func (t *plateauTracker) shouldTerminateDuration(currentValue float64, elapsed time.Duration) bool {
 	// Check if no significantly improving solutions were found during the
 	// configured duration.
 	cutoffSeconds := t.options.Duration.Seconds()
@@ -92,6 +99,12 @@ func (t *plateauTracker) ShouldTerminate(iterations int, elapsed time.Duration) 
 		}
 	}
 
+	return false
+}
+
+// shouldTerminateIterations returns true if the solver should terminate due to
+// an iterations based plateau.
+func (t *plateauTracker) shouldTerminateIterations(currentValue float64, iterations int) bool {
 	// Check if no significantly improving solutions were found during the
 	// configured iterations.
 	if t.options.Iterations > 0 && iterations >= t.options.Iterations {

--- a/solve_terminate.go
+++ b/solve_terminate.go
@@ -59,6 +59,10 @@ func (t *plateauTracker) ShouldTerminate(iterations int, elapsed time.Duration) 
 		return false
 	}
 
+	if elapsed < t.options.Delay {
+		return false
+	}
+
 	currentValue := t.progression[len(t.progression)-1].Value
 
 	return t.shouldTerminateDuration(currentValue, elapsed) ||

--- a/src/nextroute/options.py
+++ b/src/nextroute/options.py
@@ -17,6 +17,7 @@ _DURATIONS_ARGS = [
     "-check.duration",
     "-solve.duration",
     "-solve.plateau.duration",
+    "-solve.plateau.delay",
 ]
 
 # Arguments that require a string enum.
@@ -130,6 +131,8 @@ class Options(BaseModel):
     Maximum number of parallel runs, -1 results in using all available
     resources.
     """
+    SOLVE_PLATEAU_DELAY: float = 0.0
+    """Delay before starting to monitor for a plateau."""
     SOLVE_PLATEAU_ABSOLUTETHRESHOLD: float = -1
     """Absolute threshold for significant improvement."""
     SOLVE_PLATEAU_DURATION: float = 0.0

--- a/tests/check/input.json.golden
+++ b/tests/check/input.json.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/custom_constraint/input.json.golden
+++ b/tests/custom_constraint/input.json.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/custom_matrices/input.json.golden
+++ b/tests/custom_matrices/input.json.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/custom_objective/input.json.golden
+++ b/tests/custom_objective/input.json.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/custom_operators/input.json.golden
+++ b/tests/custom_operators/input.json.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/activation_penalty.json.go.golden
+++ b/tests/golden/testdata/activation_penalty.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/activation_penalty.json.python.golden
+++ b/tests/golden/testdata/activation_penalty.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/alternates.json.go.golden
+++ b/tests/golden/testdata/alternates.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/alternates.json.python.golden
+++ b/tests/golden/testdata/alternates.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/basic.json.go.golden
+++ b/tests/golden/testdata/basic.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/basic.json.python.golden
+++ b/tests/golden/testdata/basic.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/capacity.json.go.golden
+++ b/tests/golden/testdata/capacity.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/capacity.json.python.golden
+++ b/tests/golden/testdata/capacity.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/compatibility_attributes.json.go.golden
+++ b/tests/golden/testdata/compatibility_attributes.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/compatibility_attributes.json.python.golden
+++ b/tests/golden/testdata/compatibility_attributes.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/complex_precedence.json.go.golden
+++ b/tests/golden/testdata/complex_precedence.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/complex_precedence.json.python.golden
+++ b/tests/golden/testdata/complex_precedence.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/custom_data.json.go.golden
+++ b/tests/golden/testdata/custom_data.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/custom_data.json.python.golden
+++ b/tests/golden/testdata/custom_data.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/defaults.json.go.golden
+++ b/tests/golden/testdata/defaults.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/defaults.json.python.golden
+++ b/tests/golden/testdata/defaults.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/direct_precedence.json.go.golden
+++ b/tests/golden/testdata/direct_precedence.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/direct_precedence.json.python.golden
+++ b/tests/golden/testdata/direct_precedence.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/direct_precedence_linked.json.go.golden
+++ b/tests/golden/testdata/direct_precedence_linked.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/direct_precedence_linked.json.python.golden
+++ b/tests/golden/testdata/direct_precedence_linked.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/distance_matrix.json.go.golden
+++ b/tests/golden/testdata/distance_matrix.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/distance_matrix.json.python.golden
+++ b/tests/golden/testdata/distance_matrix.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/duration_groups.json.go.golden
+++ b/tests/golden/testdata/duration_groups.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/duration_groups.json.python.golden
+++ b/tests/golden/testdata/duration_groups.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/duration_groups_with_stop_multiplier.json.go.golden
+++ b/tests/golden/testdata/duration_groups_with_stop_multiplier.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/duration_groups_with_stop_multiplier.json.python.golden
+++ b/tests/golden/testdata/duration_groups_with_stop_multiplier.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/duration_matrix.json.go.golden
+++ b/tests/golden/testdata/duration_matrix.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/duration_matrix.json.python.golden
+++ b/tests/golden/testdata/duration_matrix.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/duration_matrix_time_dependent0.json.go.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent0.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/duration_matrix_time_dependent0.json.python.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent0.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/duration_matrix_time_dependent1.json.go.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent1.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/duration_matrix_time_dependent1.json.python.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent1.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/duration_matrix_time_dependent2.json.go.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent2.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/duration_matrix_time_dependent2.json.python.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent2.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/duration_matrix_time_dependent3.json.go.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent3.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/duration_matrix_time_dependent3.json.python.golden
+++ b/tests/golden/testdata/duration_matrix_time_dependent3.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/early_arrival_penalty.json.go.golden
+++ b/tests/golden/testdata/early_arrival_penalty.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/early_arrival_penalty.json.python.golden
+++ b/tests/golden/testdata/early_arrival_penalty.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/initial_stops.json.go.golden
+++ b/tests/golden/testdata/initial_stops.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/initial_stops.json.python.golden
+++ b/tests/golden/testdata/initial_stops.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/initial_stops_infeasible_compatibility.json.go.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_compatibility.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/initial_stops_infeasible_compatibility.json.python.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_compatibility.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/initial_stops_infeasible_max_duration.json.go.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_max_duration.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/initial_stops_infeasible_max_duration.json.python.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_max_duration.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/initial_stops_infeasible_remove_all.json.go.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_remove_all.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/initial_stops_infeasible_remove_all.json.python.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_remove_all.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/initial_stops_infeasible_temporal.json.go.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_temporal.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/initial_stops_infeasible_temporal.json.python.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_temporal.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/initial_stops_infeasible_tuple.json.go.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_tuple.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/initial_stops_infeasible_tuple.json.python.golden
+++ b/tests/golden/testdata/initial_stops_infeasible_tuple.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/late_arrival_penalty.json.go.golden
+++ b/tests/golden/testdata/late_arrival_penalty.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/late_arrival_penalty.json.python.golden
+++ b/tests/golden/testdata/late_arrival_penalty.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/max_distance.json.go.golden
+++ b/tests/golden/testdata/max_distance.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/max_distance.json.python.golden
+++ b/tests/golden/testdata/max_distance.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/max_duration.json.go.golden
+++ b/tests/golden/testdata/max_duration.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/max_duration.json.python.golden
+++ b/tests/golden/testdata/max_duration.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/max_stops.json.go.golden
+++ b/tests/golden/testdata/max_stops.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/max_stops.json.python.golden
+++ b/tests/golden/testdata/max_stops.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/max_wait_stop.json.go.golden
+++ b/tests/golden/testdata/max_wait_stop.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/max_wait_stop.json.python.golden
+++ b/tests/golden/testdata/max_wait_stop.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/max_wait_vehicle.json.go.golden
+++ b/tests/golden/testdata/max_wait_vehicle.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/max_wait_vehicle.json.python.golden
+++ b/tests/golden/testdata/max_wait_vehicle.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/min_stops.json.go.golden
+++ b/tests/golden/testdata/min_stops.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/min_stops.json.python.golden
+++ b/tests/golden/testdata/min_stops.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/multi_window.json.go.golden
+++ b/tests/golden/testdata/multi_window.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/multi_window.json.python.golden
+++ b/tests/golden/testdata/multi_window.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/no_mix.json.go.golden
+++ b/tests/golden/testdata/no_mix.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/no_mix.json.python.golden
+++ b/tests/golden/testdata/no_mix.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/no_mix_null.json.go.golden
+++ b/tests/golden/testdata/no_mix_null.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/no_mix_null.json.python.golden
+++ b/tests/golden/testdata/no_mix_null.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/precedence.json.go.golden
+++ b/tests/golden/testdata/precedence.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/precedence.json.python.golden
+++ b/tests/golden/testdata/precedence.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/precedence_pathologic.json.go.golden
+++ b/tests/golden/testdata/precedence_pathologic.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/precedence_pathologic.json.python.golden
+++ b/tests/golden/testdata/precedence_pathologic.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/start_level.json.go.golden
+++ b/tests/golden/testdata/start_level.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/start_level.json.python.golden
+++ b/tests/golden/testdata/start_level.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/start_time_window.json.go.golden
+++ b/tests/golden/testdata/start_time_window.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/start_time_window.json.python.golden
+++ b/tests/golden/testdata/start_time_window.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/stop_duration.json.go.golden
+++ b/tests/golden/testdata/stop_duration.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/stop_duration.json.python.golden
+++ b/tests/golden/testdata/stop_duration.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/stop_duration_multiplier.json.go.golden
+++ b/tests/golden/testdata/stop_duration_multiplier.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/stop_duration_multiplier.json.python.golden
+++ b/tests/golden/testdata/stop_duration_multiplier.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/stop_groups.json.go.golden
+++ b/tests/golden/testdata/stop_groups.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/stop_groups.json.python.golden
+++ b/tests/golden/testdata/stop_groups.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/template_input.json.go.golden
+++ b/tests/golden/testdata/template_input.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/template_input.json.python.golden
+++ b/tests/golden/testdata/template_input.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/unplanned_penalty.json.go.golden
+++ b/tests/golden/testdata/unplanned_penalty.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/unplanned_penalty.json.python.golden
+++ b/tests/golden/testdata/unplanned_penalty.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/vehicle_start_end_location.json.go.golden
+++ b/tests/golden/testdata/vehicle_start_end_location.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/vehicle_start_end_location.json.python.golden
+++ b/tests/golden/testdata/vehicle_start_end_location.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/vehicle_start_end_time.json.go.golden
+++ b/tests/golden/testdata/vehicle_start_end_time.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/vehicle_start_end_time.json.python.golden
+++ b/tests/golden/testdata/vehicle_start_end_time.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/golden/testdata/vehicles_duration_objective.json.go.golden
+++ b/tests/golden/testdata/vehicles_duration_objective.json.go.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/golden/testdata/vehicles_duration_objective.json.python.golden
+++ b/tests/golden/testdata/vehicles_duration_objective.json.python.golden
@@ -43,6 +43,7 @@
     "solve_iterations": 50,
     "solve_parallelruns": 1,
     "solve_plateau_absolutethreshold": -1,
+    "solve_plateau_delay": 0,
     "solve_plateau_duration": 0,
     "solve_plateau_iterations": 0,
     "solve_plateau_relativethreshold": 0,

--- a/tests/inline_options/input.json.golden
+++ b/tests/inline_options/input.json.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/output_options/main.sh.golden
+++ b/tests/output_options/main.sh.golden
@@ -57,6 +57,7 @@
     "iterations": 50,
     "duration": 10000000000,
     "plateau": {
+      "delay": 0,
       "duration": 0,
       "iterations": 0,
       "relative_threshold": 0,

--- a/tests/plateau_stopping_criterion/input.json.duration.golden
+++ b/tests/plateau_stopping_criterion/input.json.duration.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 500000000,
         "iterations": 0,
         "relative_threshold": 0

--- a/tests/plateau_stopping_criterion/input.json.iterations.golden
+++ b/tests/plateau_stopping_criterion/input.json.iterations.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 20,
         "relative_threshold": 0

--- a/tests/stop_balancing_objective/input.json.golden
+++ b/tests/stop_balancing_objective/input.json.golden
@@ -69,6 +69,7 @@
       "parallel_runs": 1,
       "plateau": {
         "absolute_threshold": -1,
+        "delay": 0,
         "duration": 0,
         "iterations": 0,
         "relative_threshold": 0


### PR DESCRIPTION
# Description

Fixes in issue in plateau detection where it would terminate before even reaching the given minimal length (or number of iterations).
Furthermore, adds the `-solve.plateau.delay` option for delaying the plateau detection checks. This may be helpful if solving for the first feasible solution takes significant time that should not cause plateau detection to fire.

## Changes

- Fixes plateau detection not correctly adhering to the provided minimal duration or iteration count.
- Adds `-solve.plateau.delay` parameter for delaying plateau detection checks.