### PR TITLE
Fix unplanning bug for plan one of plan unit

### DIFF
--- a/model_plan_units_unit_test.go
+++ b/model_plan_units_unit_test.go
@@ -237,6 +237,18 @@ func TestModel_NewPlanOneOfPlanUnits(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if solution.UnPlannedPlanUnits().Size() != 1 {
+		t.Fatal("solution should have 1 un-planned plan units, it has", solution.UnPlannedPlanUnits().Size())
+	}
+
+	if solution.SolutionPlanUnit(dpu1ordpu2) != solution.UnPlannedPlanUnits().SolutionPlanUnits()[0] {
+		t.Fatal("The top-level plan unit should be unplanned")
+	}
+
+	if solution.PlannedPlanUnits().Size() != 0 {
+		t.Fatal("solution should have 0 planned plan units, it has", solution.PlannedPlanUnits().Size())
+	}
+
 	move := solution.BestMove(context.Background(), solution.SolutionPlanUnit(dpu1ordpu2))
 
 	if !move.IsExecutable() {
@@ -251,9 +263,75 @@ func TestModel_NewPlanOneOfPlanUnits(t *testing.T) {
 	for _, stop := range solution.Vehicles()[0].SolutionStops() {
 		fmt.Println(stop.ModelStop().ID())
 	}
+
+	if solution.UnPlannedPlanUnits().Size() != 0 {
+		t.Fatal("solution should have 0 un-planned plan units, it has", solution.UnPlannedPlanUnits().Size())
+	}
+
+	// The solutions has two planned plan units 
+	if solution.PlannedPlanUnits().Size() != 1 {
+		t.Fatal("solution should have 1 planned plan units, it has", solution.PlannedPlanUnits().Size())
+	}
+
+	if solution.SolutionPlanUnit(dpu1ordpu2) != solution.PlannedPlanUnits().SolutionPlanUnits()[0] {
+		t.Fatal("The top-level plan unit should be planned")
+	}
+
+	solutionPlanUnit := solution.SolutionPlanUnit(dpu1ordpu2) 
+	unplanned, err := solutionPlanUnit.UnPlan()
+
+	if !unplanned {
+		t.Fatal("Could not unplan OneOfPlanUnit")
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if solutionPlanUnit.IsPlanned() {
+		t.Fatal("Could not unplan OneOfPlanUnit")
+	}
+
+	if solution.UnPlannedPlanUnits().Size() != 1 {
+		t.Fatal("solution should have 1 un-planned plan units, it has", solution.UnPlannedPlanUnits().Size())
+	}
+
+	if solution.PlannedPlanUnits().Size() != 0 {
+		t.Fatal("solution should have 0 planned plan units, it has", solution.PlannedPlanUnits().Size())
+	}
+
+	for _, stop := range solution.Vehicles()[0].SolutionStops() {
+		fmt.Println(stop.ModelStop().ID())
+	}
 }
 
 func TestPlanUnitsUnit(t *testing.T) {
+	testCases := []struct {
+		name                string
+		createPlanUnitsUnit func(model nextroute.Model, s1Unit, s2Unit nextroute.ModelPlanUnit) (nextroute.ModelPlanUnitsUnit, error)
+	}{
+		{
+			name: "PlanOneOfPlanUnits",
+			createPlanUnitsUnit: func(model nextroute.Model, s1Unit, s2Unit nextroute.ModelPlanUnit) (nextroute.ModelPlanUnitsUnit, error) {
+				return model.NewPlanOneOfPlanUnits(s1Unit, s2Unit)
+			},
+		},
+		{
+			name: "PlanAllPlanUnits",
+			createPlanUnitsUnit: func(model nextroute.Model, s1Unit, s2Unit nextroute.ModelPlanUnit) (nextroute.ModelPlanUnitsUnit, error) {
+				return model.NewPlanAllPlanUnits(true, s1Unit, s2Unit)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testPlanUnitsUnit(t, tc.createPlanUnitsUnit)
+		})
+	}
+}
+
+func testPlanUnitsUnit(t *testing.T, createPlanUnitsUnit func(model nextroute.Model, s1Unit, s2Unit nextroute.ModelPlanUnit) (nextroute.ModelPlanUnitsUnit, error)) {
 	model, err := nextroute.NewModel()
 	if err != nil {
 		t.Fatal(err)
@@ -294,7 +372,7 @@ func TestPlanUnitsUnit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s1ors2Unit, err := model.NewPlanAllPlanUnits(true, s1Unit, s2Unit)
+	s1ors2Unit, err := createPlanUnitsUnit(model, s1Unit, s2Unit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -355,6 +433,15 @@ func TestPlanUnitsUnit(t *testing.T) {
 	if !success {
 		t.Fatal("move should be successful")
 	}
+
+	if solution.PlannedPlanUnits().Size() != 1 {
+		t.Fatal("solution should have 1 planned plan units, it has", solution.PlannedPlanUnits().Size())
+	}
+
+	if solution.UnPlannedPlanUnits().Size() != 1 {
+		t.Fatal("solution should have 1 un-planned plan units, it has", solution.UnPlannedPlanUnits().Size())
+	}
+
 	move = solution.BestMove(
 		context.Background(),
 		solution.UnPlannedPlanUnits().SolutionPlanUnit(s3Unit),
@@ -373,6 +460,14 @@ func TestPlanUnitsUnit(t *testing.T) {
 	}
 	if !success {
 		t.Fatal("move should be successful")
+	}
+
+	if solution.PlannedPlanUnits().Size() != 2 {
+		t.Fatal("solution should have 2 planned plan units, it has", solution.PlannedPlanUnits().Size())
+	}
+
+	if solution.UnPlannedPlanUnits().Size() != 0 {
+		t.Fatal("solution should have 0 un-planned plan units, it has", solution.UnPlannedPlanUnits().Size())
 	}
 
 	/*

--- a/model_plan_units_unit_test.go
+++ b/model_plan_units_unit_test.go
@@ -268,7 +268,6 @@ func TestModel_NewPlanOneOfPlanUnits(t *testing.T) {
 		t.Fatal("solution should have 0 un-planned plan units, it has", solution.UnPlannedPlanUnits().Size())
 	}
 
-	// The solutions has two planned plan units 
 	if solution.PlannedPlanUnits().Size() != 1 {
 		t.Fatal("solution should have 1 planned plan units, it has", solution.PlannedPlanUnits().Size())
 	}
@@ -299,7 +298,6 @@ func TestModel_NewPlanOneOfPlanUnits(t *testing.T) {
 	if solutionPlanUnit != solution.UnPlannedPlanUnits().SolutionPlanUnits()[0] {
 		t.Fatal("The top-level plan unit should be unplanned")
 	}
-
 
 	if solution.PlannedPlanUnits().Size() != 0 {
 		t.Fatal("solution should have 0 planned plan units, it has", solution.PlannedPlanUnits().Size())

--- a/model_plan_units_unit_test.go
+++ b/model_plan_units_unit_test.go
@@ -296,6 +296,11 @@ func TestModel_NewPlanOneOfPlanUnits(t *testing.T) {
 		t.Fatal("solution should have 1 un-planned plan units, it has", solution.UnPlannedPlanUnits().Size())
 	}
 
+	if solutionPlanUnit != solution.UnPlannedPlanUnits().SolutionPlanUnits()[0] {
+		t.Fatal("The top-level plan unit should be unplanned")
+	}
+
+
 	if solution.PlannedPlanUnits().Size() != 0 {
 		t.Fatal("solution should have 0 planned plan units, it has", solution.PlannedPlanUnits().Size())
 	}

--- a/solution_move_units.go
+++ b/solution_move_units.go
@@ -11,15 +11,6 @@ func newSolutionMoveUnits(
 	planUnit *solutionPlanUnitsUnitImpl,
 	moves SolutionMoves,
 ) solutionMoveUnitsImpl {
-	if len(moves) != len(planUnit.solutionPlanUnits) {
-		panic(
-			fmt.Sprintf("moves and SolutionPlanUnits must have the same length: %v != %v",
-				len(moves),
-				len(planUnit.solutionPlanUnits),
-			),
-		)
-	}
-
 	value := 0.0
 	for _, move := range moves {
 		value += move.Value()
@@ -68,8 +59,11 @@ func (m solutionMoveUnitsImpl) Execute(ctx context.Context) (bool, error) {
 
 	m.solution.model.OnPlan(m)
 
-	m.solution.unPlannedPlanUnits.remove(m.planUnit)
-	m.solution.plannedPlanUnits.add(m.planUnit)
+	// Guarding against nested plan units unit. Only the top-level plan unit should be part of the accounting
+	if _, isElementOfPlanUnitsUnit := m.planUnit.ModelPlanUnit().PlanUnitsUnit(); !isElementOfPlanUnitsUnit {
+		m.solution.unPlannedPlanUnits.remove(m.planUnit)
+		m.solution.plannedPlanUnits.add(m.planUnit)
+	}
 
 	for idx, move := range m.moves {
 		if planned, err := move.Execute(ctx); err != nil || !planned {

--- a/solution_plan_stops_unit.go
+++ b/solution_plan_stops_unit.go
@@ -134,11 +134,7 @@ func (p *solutionPlanStopsUnitImpl) UnPlan() (bool, error) {
 
 	solution.Model().OnUnPlan(p)
 
-	if planUnitsUnit, isMemberOf := p.modelPlanStopsUnit.PlanUnitsUnit(); isMemberOf {
-		solutionPlanUnitsUnit := solution.SolutionPlanUnit(planUnitsUnit)
-		solution.plannedPlanUnits.remove(solutionPlanUnitsUnit)
-		solution.unPlannedPlanUnits.add(solutionPlanUnitsUnit)
-	} else {
+	if _, isMemberOf := p.modelPlanStopsUnit.PlanUnitsUnit(); !isMemberOf {
 		solution.plannedPlanUnits.remove(p)
 		solution.unPlannedPlanUnits.add(p)
 	}

--- a/solution_plan_units_unit.go
+++ b/solution_plan_units_unit.go
@@ -129,9 +129,11 @@ func (p *solutionPlanUnitsUnitImpl) UnPlan() (bool, error) {
 	}
 
 	solution := p.Solution().(*solutionImpl)
-
-	solution.plannedPlanUnits.remove(p)
-	solution.unPlannedPlanUnits.add(p)
+	// Guard against nested plan units unit. Only the top-level plan unit should be accounted for.
+	if _, isMemberOf := p.modelPlanUnitsUnit.PlanUnitsUnit(); !isMemberOf {
+		solution.plannedPlanUnits.remove(p)
+		solution.unPlannedPlanUnits.add(p)
+	}
 
 	for _, solutionPlanUnit := range p.solutionPlanUnits {
 		if solutionPlanUnit.IsPlanned() {

--- a/solution_vehicle.go
+++ b/solution_vehicle.go
@@ -353,12 +353,15 @@ func (v SolutionVehicle) bestMovePlanOneOfUnit(
 ) SolutionMove {
 	move := NotExecutableMove
 
-	for _, planUnit := range planUnit.solutionPlanUnits {
+	for _, pu := range planUnit.solutionPlanUnits {
 		move = move.TakeBest(
-			v.BestMove(ctx, planUnit),
+			v.BestMove(ctx, pu),
 		)
 	}
-	return move
+
+	// This returns a SolutionMoveUnits wrapper around the move. Otherwise the move cannot remove
+	// the plan unit from the solution when move.Execute() is called.
+	return newSolutionMoveUnits(planUnit, SolutionMoves{move})
 }
 
 func revertMoves(moves SolutionMoves) (bool, error) {


### PR DESCRIPTION
## Context

I spoke to @nmisek earlier this week about a bug we discovered when implementing a custom routing model. I thought it would be easiest to show you the issue with a failing test + a potential fix that we have been using internally.

The easiest way to understand what I'm talking about is to paste my updated unit tests into the develop branch and see them fail. I might have misunderstood the intent of the code but hopefully you will agree with the tests.

## Problem description

While using PlanOneOfPlanUnits to implement a disjunctive constraint on (pickup, dropoff) stop pairs, we found that the solver was giving very weird solutions. I debugged the issue and found out that the solver was unable to correctly unplan stops that were part of disjunctive constraints. 

I found the cause of this issue in `bestMovePlanOneOfUnit`. The original implementation was:

```
func (v SolutionVehicle) bestMovePlanOneOfUnit(
	ctx context.Context,
	planUnit *solutionPlanUnitsUnitImpl,
) SolutionMove {
	move := NotExecutableMove

	for _, planUnit := range planUnit.solutionPlanUnits {
		move = move.TakeBest(
			v.BestMove(ctx, planUnit),
		)
	}
	return move
}
```

The function returns a move associated with a StopPlanUnit (assuming no nesting of PlanOneOfPlanUnits) instead of the PlanOneOfPlanUnit that is passed to the function. When the move is executed, stops are attached to the solution but the bookkeeping of planned / unplanned PlanUnits is not done correctly. Hence you end up with stops attached to solutions, but the disjunctive plan unit is marked as unplanned (see test "TestPlanUnitsUnit/PlanOneOfPlanUnits"). This explains why we observed that the solver was unable to unplan the stops.

When I was writing up this PR and the tests for this problem, I also discovered that the same bookkeeping is wrong for nested PlanOneOfPlanUnit (see test: "TestModel_NewPlanOneOfPlanUnits"). I discovered this because the existing tests include these nested structures but they didn't catch the unplanned/planned weirdness. We don't use nested disjunctive constraints, but I wanted to point this out to you here as well.

## Fix

The solution to our core problem was to return a corrected move in `bestMovePlanOneOfUnit`

```
return newSolutionMoveUnits(planUnit, SolutionMoves{move})
```

and removing a constraint inside `newSolutionMoveUnits()`

The rest of the code is related to fixing the planned / unplanned bookkeeping of nested PlanOneOfPlanUnits.