### PR TITLE
Fix floating point precision errors when checking location equality

### DIFF
--- a/common/location.go
+++ b/common/location.go
@@ -103,7 +103,8 @@ func (l Location) Latitude() float64 {
 
 // Equals returns true if the invoking location is equal to the other location.
 func (l Location) Equals(other Location) bool {
-	return l.longitude == other.Longitude() && l.latitude == other.Latitude()
+	const tolerance = 0.000001
+	return WithinTolerance(l.latitude, other.latitude, tolerance) && WithinTolerance(l.longitude, other.longitude, tolerance)
 }
 
 // IsValid returns true if the location is valid. A location is valid if


### PR DESCRIPTION
Another quick PR that's more straightforward than #91

Direct floating point comparisons are affecting the unplan operator when it tries to unplan stops at the same location. 

I haven't done proper tests of how this changes performance (I guess it is possible that the added randomness aids the search in some scenarios) 