### PR TITLE
Fixes 0 iteration limit waiting indefinitely

### DIFF
--- a/.nextmv/benchmark.requirements.txt
+++ b/.nextmv/benchmark.requirements.txt
@@ -1,2 +1,2 @@
-nextmv>=v0.14.2
+nextmv>=0.29.5.dev1
 requests>=2.32.3

--- a/solve_solver_parallel.go
+++ b/solve_solver_parallel.go
@@ -311,7 +311,9 @@ func (s *parallelSolverImpl) Solve(
 	var waitGroup sync.WaitGroup
 
 	go func() {
-		defer close(syncResultChannel)
+		defer func() {
+			close(syncResultChannel)
+		}()
 		runCount := 0
 	Loop:
 		for {
@@ -379,13 +381,20 @@ func (s *parallelSolverImpl) Solve(
 							panic(err)
 						}
 
+						// Adjust the total iterations left by the ones we are
+						// about to run.
 						updatedIterations := iterationsLeft.Add(int64(opt.Iterations) * -1)
-						if updatedIterations+int64(opt.Iterations) <= 0 {
+						// Make sure we do not run more iterations than left.
+						if updatedIterations < 0 {
+							opt.Iterations += int(updatedIterations)
+						}
+						// If we are out of iterations stop this run.
+						if opt.Iterations <= 0 {
+							if totalIterations.Load() >= int64(interpretedParallelSolveOptions.Iterations) {
+								cancel()
+							}
 							<-ctx.Done()
 							return
-						}
-						if updatedIterations < 0 {
-							opt.Iterations = int(updatedIterations + int64(opt.Iterations))
 						}
 
 						s.ParallelSolveEvents().StartSolver.Trigger(

--- a/solve_solver_parallel.go
+++ b/solve_solver_parallel.go
@@ -311,9 +311,7 @@ func (s *parallelSolverImpl) Solve(
 	var waitGroup sync.WaitGroup
 
 	go func() {
-		defer func() {
-			close(syncResultChannel)
-		}()
+		defer close(syncResultChannel)
 		runCount := 0
 	Loop:
 		for {


### PR DESCRIPTION
# Description

Fixes the solver waiting indefinitely (or until running out of time) when configuring a 0 iteration limit.

## Changes

- Fixes the solver waiting forever (or until timeout) when configuring `-solve.duration=0`.

Resolves ENG-6537