### PR TITLE
Improve Solution struct

### DIFF
--- a/model.go
+++ b/model.go
@@ -201,7 +201,8 @@ func NewModel() (Model, error) {
 		distanceUnit:                   common.Meters,
 		durationUnit:                   time.Second,
 		epoch:                          time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
-		expressions:                    make(map[int]ModelExpression),
+		expressions:                    []ModelExpression{},
+		expressionsIndexMap:            map[int]int{},
 		isLocked:                       false,
 		objective:                      nil,
 		objectivesWithStopUpdater:      make(ModelObjectives, 0),
@@ -239,10 +240,12 @@ func NewModel() (Model, error) {
 type modelImpl struct {
 	epoch time.Time
 	modelDataImpl
-	objective                  ModelObjectiveSum
-	stopVehicles               map[int]int
-	random                     *rand.Rand
-	expressions                map[int]ModelExpression
+	objective    ModelObjectiveSum
+	stopVehicles map[int]int
+	random       *rand.Rand
+	expressions  []ModelExpression
+	// expressionsIndexMap maps expression index to its position
+	expressionsIndexMap        map[int]int
 	constraintMap              map[CheckedAt]ModelConstraints
 	timeFormat                 string
 	constraints                ModelConstraints
@@ -350,7 +353,8 @@ func (m *modelImpl) NewVehicleType(
 }
 
 func (m *modelImpl) addExpression(expression ModelExpression) error {
-	if existingExpression, ok := m.expressions[expression.Index()]; ok {
+	if eIdx, ok := m.expressionsIndexMap[expression.Index()]; ok {
+		existingExpression := m.expressions[eIdx]
 		if existingExpression.Name() != expression.Name() {
 			return fmt.Errorf(
 				"expression index %d already exists with name %s,"+
@@ -362,7 +366,8 @@ func (m *modelImpl) addExpression(expression ModelExpression) error {
 			)
 		}
 	} else {
-		m.expressions[expression.Index()] = expression
+		m.expressions = append(m.expressions, expression)
+		m.expressionsIndexMap[expression.Index()] = len(m.expressions) - 1
 	}
 	return nil
 }

--- a/solution.go
+++ b/solution.go
@@ -139,8 +139,8 @@ func NewSolution(
 		slack:                    make([]float64, 0, nrStops),
 		start:                    make([]float64, 0, nrStops),
 		end:                      make([]float64, 0, nrStops),
-		values:                   make(map[int][]float64, nExpressions),
-		cumulativeValues:         make(map[int][]float64, nExpressions),
+		values:                   make([][]float64, nExpressions),
+		cumulativeValues:         make([][]float64, nExpressions),
 		stopToPlanUnit:           make([]*solutionPlanStopsUnitImpl, nrStops),
 		constraintStopData:       make(map[ModelConstraint][]Copier),
 		objectiveStopData:        make(map[ModelObjective][]Copier),
@@ -166,9 +166,9 @@ func NewSolution(
 		),
 	}
 
-	for _, expression := range model.expressions {
-		solution.values[expression.Index()] = make([]float64, nrStops)
-		solution.cumulativeValues[expression.Index()] = make([]float64, nrStops)
+	for ei := range model.expressions {
+		solution.values[ei] = make([]float64, nrStops)
+		solution.cumulativeValues[ei] = make([]float64, nrStops)
 	}
 
 	for _, constraint := range model.constraintsWithStopUpdater {
@@ -574,13 +574,13 @@ func (s *solutionImpl) addInitialSolution(m Model) error {
 type solutionImpl struct {
 	model                  Model
 	scores                 map[ModelObjective]float64
-	values                 map[int][]float64
+	values                 [][]float64
+	cumulativeValues       [][]float64
 	objectiveStopData      map[ModelObjective][]Copier
 	constraintStopData     map[ModelConstraint][]Copier
 	objectiveVehicleData   map[ModelObjective][]Copier
 	objectiveSolutionData  map[ModelObjective]Copier
 	constraintSolutionData map[ModelConstraint]Copier
-	cumulativeValues       map[int][]float64
 
 	// TODO: explore if stopToPlanUnit should rather contain interfaces
 	stopToPlanUnit       []*solutionPlanStopsUnitImpl
@@ -713,7 +713,7 @@ func (s *solutionImpl) Copy() Solution {
 		constraintSolutionData:   make(map[ModelConstraint]Copier, len(s.constraintSolutionData)),
 		objectiveSolutionData:    make(map[ModelObjective]Copier, len(s.objectiveSolutionData)),
 		cumulativeTravelDuration: cumulativeTravelDuration,
-		cumulativeValues:         make(map[int][]float64, len(s.cumulativeValues)),
+		cumulativeValues:         make([][]float64, len(s.cumulativeValues)),
 		stopToPlanUnit:           make([]*solutionPlanStopsUnitImpl, len(s.stopToPlanUnit)),
 		end:                      end,
 		first:                    first,
@@ -725,7 +725,7 @@ func (s *solutionImpl) Copy() Solution {
 		start:                    start,
 		stop:                     stop,
 		stopPosition:             stopPosition,
-		values:                   make(map[int][]float64, len(s.values)),
+		values:                   make([][]float64, len(s.values)),
 		vehicleIndices:           vehicleIndices,
 		random:                   random,
 		fixedPlanUnits: newSolutionPlanUnitCollectionBaseImpl(
@@ -751,8 +751,7 @@ func (s *solutionImpl) Copy() Solution {
 		solution.solutionVehicles[idx] = solution.vehicles[idx]
 	}
 
-	for _, expression := range model.expressions {
-		eIndex := expression.Index()
+	for eIndex := range model.expressions {
 		solution.cumulativeValues[eIndex], floats = common.CopySliceFrom(floats, s.cumulativeValues[eIndex])
 		solution.values[eIndex], floats = common.CopySliceFrom(floats, s.values[eIndex])
 	}
@@ -882,19 +881,19 @@ func (s *solutionImpl) newVehicle(
 		solution: s,
 	})
 
-	for _, expression := range model.expressions {
+	for ei, expression := range model.expressions {
 		value := expression.Value(
 			modelVehicle.VehicleType(),
 			modelVehicle.First(),
 			modelVehicle.First(),
 		)
-		s.values[expression.Index()] = append(
-			s.values[expression.Index()],
+		s.values[ei] = append(
+			s.values[ei],
 			value,
 			0,
 		)
-		s.cumulativeValues[expression.Index()] = append(
-			s.cumulativeValues[expression.Index()],
+		s.cumulativeValues[ei] = append(
+			s.cumulativeValues[ei],
 			value,
 			value,
 		)
@@ -1147,14 +1146,16 @@ func (s *solutionImpl) value(
 	expression ModelExpression,
 	index int,
 ) float64 {
-	return s.values[expression.Index()][index]
+	idx := s.model.(*modelImpl).expressionsIndexMap[expression.Index()]
+	return s.values[idx][index]
 }
 
 func (s *solutionImpl) cumulativeValue(
 	expression ModelExpression,
 	index int,
 ) float64 {
-	return s.cumulativeValues[expression.Index()][index]
+	idx := s.model.(*modelImpl).expressionsIndexMap[expression.Index()]
+	return s.cumulativeValues[idx][index]
 }
 
 func (s *solutionImpl) constraintValue(
@@ -1253,14 +1254,14 @@ func (s *solutionImpl) isFeasible(index int, includeTemporal bool) (
 		end := s.end[index]
 		next := s.next[index]
 
-		for _, expression := range model.expressions {
+		for ei, expression := range model.expressions {
 			value := expression.Value(
 				vehicleType,
 				model.stops[s.stop[index]],
 				model.stops[s.stop[next]],
 			)
-			s.values[expression.Index()][next] = value
-			s.cumulativeValues[expression.Index()][next] = s.cumulativeValues[expression.Index()][index] + value
+			s.values[ei][next] = value
+			s.cumulativeValues[ei][next] = s.cumulativeValues[ei][index] + value
 		}
 
 		travelDuration, arrival, start, end := vehicleType.TemporalValues(


### PR DESCRIPTION
The goal here is to remove the two maps from the Solution struct in order to improve performance.

This approach is purely internal at the expense of a map lookup when getting the `value` and `cummulativeValue` by expression and index.