### PR TITLE
Improve maximum objective value performance

### DIFF
--- a/model_maximum.go
+++ b/model_maximum.go
@@ -420,13 +420,16 @@ func (l *maximumImpl) Value(
 			}
 			continue
 		}
-
-		for _, solutionStop := range vehicle.SolutionStops() {
-			solutionStop.CumulativeValue(l.resourceExpression)
+		solutionStop := vehicle.First()
+		for {
 			excess := solutionStop.CumulativeValue(l.resourceExpression) - maximum
 			if excess > 0 {
 				score += excess
 			}
+			if solutionStop.IsLast() {
+				break
+			}
+			solutionStop = solutionStop.Next()
 		}
 	}
 


### PR DESCRIPTION
This improves the performance of the maximum objective value by removing an unnecessary allocation while iterating the stops. It also removes an accidental double computation of the excess score.