### PR TITLE
Add epsilon comparison for maximum constraint

### DIFF
--- a/.github/workflows/auto-benchmark.yml
+++ b/.github/workflows/auto-benchmark.yml
@@ -1,8 +1,9 @@
 name: auto benchmark
 on:
+  workflow_dispatch:
   push:
     branches:
-      - "**"
+      - "develop"
 
 env:
   GO_VERSION: 1.25

--- a/.github/workflows/go-test-lint.yml
+++ b/.github/workflows/go-test-lint.yml
@@ -1,5 +1,8 @@
 name: go
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   GO_VERSION: 1.22.0

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -1,5 +1,8 @@
 name: header
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   check-header:
     runs-on: ubuntu-latest

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -1,5 +1,8 @@
 name: json
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   json-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,5 +1,8 @@
 name: markdown
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,5 +1,8 @@
 name: python lint
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   python-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -6,18 +6,14 @@ on:
 jobs:
   python-lint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: git clone
         uses: actions/checkout@v4
 
-      - name: set up Python ${{ matrix.python-version }}
+      - name: set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.13
 
       - name: install dependencies
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,8 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        platform: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-version: ["3.9", "3.13"]
+        platform:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            windows-latest,
+            macos-latest,
+            macos-13,
+          ]
     steps:
       - name: git clone
         uses: actions/checkout@v4

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,5 +1,8 @@
 name: python test
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   GO_VERSION: 1.23

--- a/model_constraint_maximum_stops.go
+++ b/model_constraint_maximum_stops.go
@@ -29,19 +29,19 @@ func NewMaximumStopsConstraint(
 
 type maximumStopsConstraintImpl struct {
 	maximumStops              VehicleTypeExpression
-	maximumStopsByVehicleType []float64
+	maximumStopsByVehicleType []int
 	modelConstraintImpl
 }
 
 func (l *maximumStopsConstraintImpl) Lock(model Model) error {
 	vehicleTypes := model.VehicleTypes()
-	l.maximumStopsByVehicleType = make([]float64, len(vehicleTypes))
+	l.maximumStopsByVehicleType = make([]int, len(vehicleTypes))
 	for _, vehicleType := range vehicleTypes {
-		l.maximumStopsByVehicleType[vehicleType.Index()] = l.maximumStops.Value(
+		l.maximumStopsByVehicleType[vehicleType.Index()] = int(l.maximumStops.Value(
 			vehicleType,
 			nil,
 			nil,
-		)
+		))
 	}
 	return nil
 }
@@ -63,8 +63,7 @@ func (l *maximumStopsConstraintImpl) EstimateIsViolated(
 	vehicleType := vehicle.ModelVehicle().VehicleType().Index()
 	maximumStops := l.maximumStopsByVehicleType[vehicleType]
 
-	if float64(vehicle.NumberOfStops()+nrStopsToBeAddedToSolution) >
-		maximumStops {
+	if vehicle.NumberOfStops()+nrStopsToBeAddedToSolution > maximumStops {
 		return true, constSkipVehiclePositionsHint
 	}
 

--- a/model_maximum.go
+++ b/model_maximum.go
@@ -7,6 +7,8 @@ import (
 	"math"
 )
 
+const EPSILON = float64(1e-10)
+
 // Maximum can be used as a constraint or an objective that limits the maximum
 // cumulative value can be assigned to a vehicle type. The maximum cumulative
 // value is defined by the expression and the maximum value is defined by the
@@ -124,7 +126,7 @@ func (l *maximumImpl) Lock(model Model) error {
 		for _, stop := range planUnit.Stops() {
 			value := l.Expression().Value(nil, nil, stop)
 			delta += value
-			if value != 0 {
+			if value > EPSILON || value < -EPSILON {
 				hasNoEffect = false
 			}
 		}
@@ -185,7 +187,7 @@ func (l *maximumImpl) DoesStopHaveViolations(s SolutionStop) bool {
 		nil,
 	)
 
-	return cumulativeValue > maximum || cumulativeValue < 0.0
+	return cumulativeValue > maximum+EPSILON || cumulativeValue < -EPSILON
 }
 
 func (l *maximumImpl) EstimateIsViolated(
@@ -212,7 +214,7 @@ func (l *maximumImpl) EstimateIsViolated(
 
 	if l.hasConstantExpression {
 		value := expression.Value(nil, nil, nil)
-		if value > maximum || value < 0 {
+		if value > maximum+EPSILON || value < -EPSILON {
 			return true, constSkipVehiclePositionsHint
 		}
 		return false, constNoPositionsHint
@@ -247,7 +249,7 @@ func (l *maximumImpl) EstimateIsViolated(
 			modelStop,
 		)
 
-		if level > maximum || level < 0 {
+		if level > maximum+EPSILON || level < -EPSILON {
 			return true, constNoPositionsHint
 		}
 		previousStop = solutionStop
@@ -268,7 +270,7 @@ func (l *maximumImpl) EstimateIsViolated(
 		for !stop.IsLast() {
 			level += stop.Value(expression)
 
-			if level > maximum || level < 0 {
+			if level > maximum+EPSILON || level < -EPSILON {
 				// TODO we can hint the move has to be past this stop
 				return true, constNoPositionsHint
 			}
@@ -298,15 +300,17 @@ func (l *maximumImpl) UpdateObjectiveStopData(
 			hasViolation: false,
 		}, nil
 	}
+
 	hasViolation := solutionStop.Previous().ObjectiveData(l).(*maximumObjectiveDate).hasViolation
 
 	if !hasViolation {
-		maximum := l.maximumByVehicleType[solutionStop.Vehicle().ModelVehicle().VehicleType().Index()]
 		value := solutionStop.CumulativeValue(l.resourceExpression)
-		if value > maximum || value < 0 {
+		maximum := l.maximumByVehicleType[solutionStop.Vehicle().ModelVehicle().VehicleType().Index()]
+		if value > maximum+EPSILON || value < -EPSILON {
 			hasViolation = true
 		}
 	}
+
 	return &maximumObjectiveDate{
 		hasViolation: hasViolation,
 	}, nil
@@ -330,10 +334,10 @@ func (l *maximumImpl) EstimateDeltaValue(
 
 	if l.hasConstantExpression {
 		value := l.resourceExpression.Value(nil, nil, nil)
-		if value > maximum {
+		if value > maximum+EPSILON {
 			return value - maximum + l.penaltyOffset
 		}
-		if value < 0 {
+		if value < -EPSILON {
 			return math.Abs(value) + l.penaltyOffset
 		}
 		return 0.0
@@ -348,7 +352,7 @@ func (l *maximumImpl) EstimateDeltaValue(
 
 		returnValue := 0.0
 		excess := cumulativeValue + l.deltas[moveImpl.planUnit.modelPlanStopsUnit.Index()] - maximum
-		if excess > 0 {
+		if excess > EPSILON {
 			if !hasViolation {
 				returnValue += l.penaltyOffset
 			}
@@ -361,7 +365,6 @@ func (l *maximumImpl) EstimateDeltaValue(
 
 	generator := newSolutionStopGenerator(*moveImpl, false, true)
 	defer generator.release()
-
 	previousStop, _ := generator.next()
 
 	level := previousStop.CumulativeValue(l.resourceExpression)
@@ -375,12 +378,12 @@ func (l *maximumImpl) EstimateDeltaValue(
 			modelStop,
 		)
 
-		if level > maximum || level < 0 {
+		if level > maximum+EPSILON || level < -EPSILON {
 			deltaViolation := level - maximum
 			if solutionStop.IsPlanned() {
 				deltaViolation -= solutionStop.CumulativeValue(l.resourceExpression)
 			}
-			if deltaViolation > 0. {
+			if deltaViolation > EPSILON {
 				estimateDeltaValue += deltaViolation
 				if !hasViolation {
 					estimateDeltaValue += l.penaltyOffset
@@ -415,7 +418,7 @@ func (l *maximumImpl) Value(
 		if l.hasStopExpressionAndNoNegativeValues {
 			cumulativeValue := vehicle.Last().CumulativeValue(l.resourceExpression)
 			excess := cumulativeValue - maximum
-			if excess > 0 {
+			if excess > EPSILON {
 				score += excess
 			}
 			continue
@@ -423,7 +426,7 @@ func (l *maximumImpl) Value(
 		solutionStop := vehicle.First()
 		for {
 			excess := solutionStop.CumulativeValue(l.resourceExpression) - maximum
-			if excess > 0 {
+			if excess > EPSILON {
 				score += excess
 			}
 			if solutionStop.IsLast() {

--- a/model_maximum.go
+++ b/model_maximum.go
@@ -7,8 +7,6 @@ import (
 	"math"
 )
 
-const EPSILON = float64(1e-10)
-
 // Maximum can be used as a constraint or an objective that limits the maximum
 // cumulative value can be assigned to a vehicle type. The maximum cumulative
 // value is defined by the expression and the maximum value is defined by the
@@ -126,7 +124,7 @@ func (l *maximumImpl) Lock(model Model) error {
 		for _, stop := range planUnit.Stops() {
 			value := l.Expression().Value(nil, nil, stop)
 			delta += value
-			if value > EPSILON || value < -EPSILON {
+			if nonZero(value) {
 				hasNoEffect = false
 			}
 		}
@@ -187,7 +185,7 @@ func (l *maximumImpl) DoesStopHaveViolations(s SolutionStop) bool {
 		nil,
 	)
 
-	return cumulativeValue > maximum+EPSILON || cumulativeValue < -EPSILON
+	return outOf0Range(cumulativeValue, maximum)
 }
 
 func (l *maximumImpl) EstimateIsViolated(
@@ -214,7 +212,7 @@ func (l *maximumImpl) EstimateIsViolated(
 
 	if l.hasConstantExpression {
 		value := expression.Value(nil, nil, nil)
-		if value > maximum+EPSILON || value < -EPSILON {
+		if outOf0Range(value, maximum) {
 			return true, constSkipVehiclePositionsHint
 		}
 		return false, constNoPositionsHint
@@ -249,7 +247,7 @@ func (l *maximumImpl) EstimateIsViolated(
 			modelStop,
 		)
 
-		if level > maximum+EPSILON || level < -EPSILON {
+		if outOf0Range(level, maximum) {
 			return true, constNoPositionsHint
 		}
 		previousStop = solutionStop
@@ -270,7 +268,7 @@ func (l *maximumImpl) EstimateIsViolated(
 		for !stop.IsLast() {
 			level += stop.Value(expression)
 
-			if level > maximum+EPSILON || level < -EPSILON {
+			if outOf0Range(level, maximum) {
 				// TODO we can hint the move has to be past this stop
 				return true, constNoPositionsHint
 			}
@@ -306,7 +304,7 @@ func (l *maximumImpl) UpdateObjectiveStopData(
 	if !hasViolation {
 		value := solutionStop.CumulativeValue(l.resourceExpression)
 		maximum := l.maximumByVehicleType[solutionStop.Vehicle().ModelVehicle().VehicleType().Index()]
-		if value > maximum+EPSILON || value < -EPSILON {
+		if outOf0Range(value, maximum) {
 			hasViolation = true
 		}
 	}
@@ -334,10 +332,10 @@ func (l *maximumImpl) EstimateDeltaValue(
 
 	if l.hasConstantExpression {
 		value := l.resourceExpression.Value(nil, nil, nil)
-		if value > maximum+EPSILON {
+		if greaterThan(value, maximum) {
 			return value - maximum + l.penaltyOffset
 		}
-		if value < -EPSILON {
+		if lessThanZero(value) {
 			return math.Abs(value) + l.penaltyOffset
 		}
 		return 0.0
@@ -352,7 +350,7 @@ func (l *maximumImpl) EstimateDeltaValue(
 
 		returnValue := 0.0
 		excess := cumulativeValue + l.deltas[moveImpl.planUnit.modelPlanStopsUnit.Index()] - maximum
-		if excess > EPSILON {
+		if greaterThanZero(excess) {
 			if !hasViolation {
 				returnValue += l.penaltyOffset
 			}
@@ -378,12 +376,12 @@ func (l *maximumImpl) EstimateDeltaValue(
 			modelStop,
 		)
 
-		if level > maximum+EPSILON || level < -EPSILON {
+		if outOf0Range(level, maximum) {
 			deltaViolation := level - maximum
 			if solutionStop.IsPlanned() {
 				deltaViolation -= solutionStop.CumulativeValue(l.resourceExpression)
 			}
-			if deltaViolation > EPSILON {
+			if greaterThanZero(deltaViolation) {
 				estimateDeltaValue += deltaViolation
 				if !hasViolation {
 					estimateDeltaValue += l.penaltyOffset
@@ -418,7 +416,7 @@ func (l *maximumImpl) Value(
 		if l.hasStopExpressionAndNoNegativeValues {
 			cumulativeValue := vehicle.Last().CumulativeValue(l.resourceExpression)
 			excess := cumulativeValue - maximum
-			if excess > EPSILON {
+			if greaterThanZero(excess) {
 				score += excess
 			}
 			continue
@@ -426,7 +424,7 @@ func (l *maximumImpl) Value(
 		solutionStop := vehicle.First()
 		for {
 			excess := solutionStop.CumulativeValue(l.resourceExpression) - maximum
-			if excess > EPSILON {
+			if greaterThanZero(excess) {
 				score += excess
 			}
 			if solutionStop.IsLast() {
@@ -441,4 +439,39 @@ func (l *maximumImpl) Value(
 	}
 
 	return score
+}
+
+const (
+	// epsilon is used to compare floating point numbers for equality. This is
+	// used only by the maximum constraint for now.
+	epsilon float64 = 1e-12
+)
+
+// greaterThanZero returns true if value is greater than zero considering a
+// small epsilon.
+func greaterThanZero(value float64) bool {
+	return value > epsilon
+}
+
+// lessThanZero returns true if value is less than zero considering a small
+// epsilon.
+func lessThanZero(value float64) bool {
+	return value < -epsilon
+}
+
+// nonZero returns true if value is not zero considering a small epsilon.
+func nonZero(value float64) bool {
+	return math.Abs(value) > epsilon
+}
+
+// outOf0Range returns true if value is less than zero or greater than max
+// considering a small epsilon.
+func outOf0Range(value, max float64) bool {
+	return value < -epsilon || value > max+epsilon
+}
+
+// greaterThan returns true if value is greater than threshold considering a
+// small epsilon.
+func greaterThan(value, threshold float64) bool {
+	return value > threshold+epsilon
 }

--- a/model_maximum.go
+++ b/model_maximum.go
@@ -466,8 +466,8 @@ func nonZero(value float64) bool {
 
 // outOf0Range returns true if value is less than zero or greater than max
 // considering a small epsilon.
-func outOf0Range(value, max float64) bool {
-	return value < -epsilon || value > max+epsilon
+func outOf0Range(value, maximum float64) bool {
+	return value < -epsilon || value > maximum+epsilon
 }
 
 // greaterThan returns true if value is greater than threshold considering a


### PR DESCRIPTION
# Description

Extends the maximum constraint with epsilon comparison to better account for numerical inaccuracies. For now, we assume a fixed epsilon of `1e-12`. If this is insufficient to users we are open to make this configurable or loosen it up more by default, however, we wanted to start conservatively.
While we were at it, we noticed a small improvement we could do to the maximum stops constraint by making it work on int instead of float internally (for slightly improved speed and accuracy). We added the improvement to this PR.
Furthermore, we bundled some updates to our workflows to make them friendlier for external PRs to execute and reduced the number of action runs in general. This was just for plumbing.

## Changes

- Adds epsilon of `1e-12` to the base maximum constraint to fix numerical inaccuracies due to the float handling.
- Changed maximum stops constraint to deal with int directly instead of float for accuracy and performance reasons.
- Allows workflows to be run on external contributions more easily.
- Reduced the number of workflows run substantially.

## Original contributor's description

Thanks to @TheMarex for reporting and contributing! :heart: 

We have been having issues with the capacity constraint if the resources on vehicles are not integers that can be represented precisely in a float64.

Given the underlying type here is a float I would expect the logic to account for the floating point arithmetics. Simple example:

If you have some pickups and drop-offs

```
2.1 + 2 + 3.1 - 2.1 - 2 - 3.1
```

This will not be zero. If you then pickup something large the result should fit in the capacity limit but it doesn't because there is a small epsilon that is simply noise from the arithmetic calculations.

This is the internal fix we are using - the epsilon is chosen at random, it could be much smaller. `2^-53 * (NUM_OPERATIONS+1)` is a safe limit usually. If you want to be precise to could try to determine that based on the number of stops? Practically speaking I think the fixed value is fine for real-world values.