### PR TITLE
Simplify stop position hints

### DIFF
--- a/model_cluster.go
+++ b/model_cluster.go
@@ -213,7 +213,7 @@ func (l *Cluster) estimateDeltaScore(
 	for _, stopPosition := range stopPositions {
 		vehicle := moveImpl.vehicle()
 		if vehicle.IsEmpty() {
-			return deltaScore, constNoPositionsHint
+			return deltaScore, NoPositionsHint()
 		}
 
 		candidate := stopPosition.Stop()
@@ -246,7 +246,7 @@ func (l *Cluster) estimateDeltaScore(
 					centroidOtherVehicle,
 					candidate.ModelStop().Location(),
 				).Value(common.Meters) < distanceToCentroid {
-					return 1.0, constSkipVehiclePositionsHint
+					return 1.0, SkipVehiclePositionsHint()
 				}
 			}
 		} else {
@@ -257,7 +257,7 @@ func (l *Cluster) estimateDeltaScore(
 			deltaScore -= c.compactness
 		}
 	}
-	return deltaScore, constNoPositionsHint
+	return deltaScore, NoPositionsHint()
 }
 
 func (l *Cluster) getSolutionStops(vehicle SolutionVehicle) []SolutionStop {

--- a/model_constraint_attributes.go
+++ b/model_constraint_attributes.go
@@ -149,9 +149,9 @@ func (l *AttributesConstraint) EstimateIsViolated(
 	idx := l.mapTwoIndices(planUnitIdx, vehicleType.Index())
 	compatible := l.compatible[idx]
 	if compatible {
-		return false, constNoPositionsHint
+		return false, NoPositionsHint()
 	}
-	return true, constSkipVehiclePositionsHint
+	return true, SkipVehiclePositionsHint()
 }
 
 func (l *AttributesConstraint) mapTwoIndices(i, j int) int {

--- a/model_constraint_maximum_duration.go
+++ b/model_constraint_maximum_duration.go
@@ -72,7 +72,7 @@ func (l *MaximumDurationConstraint) EstimateIsViolated(
 		)
 
 		if endValue-startValue > maximumValue {
-			return true, constNoPositionsHint
+			return true, NoPositionsHint()
 		}
 
 		previousStop = solutionStop
@@ -81,10 +81,10 @@ func (l *MaximumDurationConstraint) EstimateIsViolated(
 	deltaEnd := endValue - previousStop.EndValue() - previousStop.SlackValue()
 
 	if vehicle.DurationValue()+deltaEnd > maximumValue {
-		return true, constNoPositionsHint
+		return true, NoPositionsHint()
 	}
 
-	return false, constNoPositionsHint
+	return false, NoPositionsHint()
 }
 
 // DoesVehicleHaveViolations returns whether the given vehicle has violations

--- a/model_constraint_maximum_stops.go
+++ b/model_constraint_maximum_stops.go
@@ -56,10 +56,10 @@ func (l *MaximumStopsConstraint) EstimateIsViolated(
 
 	if float64(vehicle.NumberOfStops()+nrStopsToBeAddedToSolution) >
 		maximumStops {
-		return true, constSkipVehiclePositionsHint
+		return true, SkipVehiclePositionsHint()
 	}
 
-	return false, constNoPositionsHint
+	return false, NoPositionsHint()
 }
 
 // EstimationCost returns the cost of the constraint for estimation purposes.

--- a/model_constraint_maximum_travel_duration.go
+++ b/model_constraint_maximum_travel_duration.go
@@ -68,7 +68,7 @@ func (l *MaximumTravelDurationConstraint) EstimateIsViolated(
 		value += travelDuration
 
 		if value+cumulativeDurationAtStart > maximum {
-			return true, constNoPositionsHint
+			return true, NoPositionsHint()
 		}
 
 		previousStop = solutionStop
@@ -79,10 +79,10 @@ func (l *MaximumTravelDurationConstraint) EstimateIsViolated(
 	delta := value - next.CumulativeTravelDurationValue()
 
 	if vehicle.Last().CumulativeTravelDurationValue()+delta > maximum {
-		return true, constNoPositionsHint
+		return true, NoPositionsHint()
 	}
 
-	return false, constNoPositionsHint
+	return false, NoPositionsHint()
 }
 
 // DoesVehicleHaveViolations returns true if the vehicle has violations of

--- a/model_constraint_maximum_wait_stop.go
+++ b/model_constraint_maximum_wait_stop.go
@@ -87,13 +87,13 @@ func (l *MaximumWaitStopConstraint) EstimateIsViolated(
 		wait := start - arrival
 
 		if wait > l.maxima.Value(nil, nil, to.ModelStop()) {
-			return true, constNoPositionsHint
+			return true, NoPositionsHint()
 		}
 
 		from = to
 	}
 
-	return false, constNoPositionsHint
+	return false, NoPositionsHint()
 }
 
 // DoesStopHaveViolations returns true if the stop has violations of the

--- a/model_constraint_maximum_wait_vehicle.go
+++ b/model_constraint_maximum_wait_vehicle.go
@@ -123,13 +123,13 @@ func (l *MaximumWaitVehicleConstraint) EstimateIsViolated(
 		wait := start - arrival
 		accumulatedWait += wait
 		if accumulatedWait > maxWait {
-			return true, constNoPositionsHint
+			return true, NoPositionsHint()
 		}
 
 		from = to
 	}
 
-	return false, constNoPositionsHint
+	return false, NoPositionsHint()
 }
 
 // DoesStopHaveViolations returns true if the stop has violations of the

--- a/model_constraint_no_mix.go
+++ b/model_constraint_no_mix.go
@@ -347,7 +347,7 @@ func (l *NoMixConstraint) EstimateIsViolated(
 	moveImpl := move.(*solutionMoveStopsImpl)
 	_, hasRemoveMixItem := l.remove[moveImpl.stopPositions[0].Stop().ModelStop()]
 	if hasRemoveMixItem {
-		return true, constNoPositionsHint
+		return true, NoPositionsHint()
 	}
 
 	previousStopImp := moveImpl.stopPositions[0].Previous()
@@ -360,7 +360,7 @@ func (l *NoMixConstraint) EstimateIsViolated(
 	insertMixItem, hasInsertMixItem := l.insert[moveImpl.stopPositions[0].Stop().ModelStop()]
 	if hasInsertMixItem {
 		if contentName != insertMixItem.Name && previousNoMixData.content.Quantity != 0 {
-			return true, constNoPositionsHint
+			return true, NoPositionsHint()
 		}
 		deltaQuantity += insertMixItem.Quantity
 	}
@@ -370,7 +370,7 @@ func (l *NoMixConstraint) EstimateIsViolated(
 		// cannot be violated (as it is not mixing any new item between existing
 		// ones). Note that the content name of all stops of a move is the same,
 		// so it is enough to check the first stop.
-		return false, constNoPositionsHint
+		return false, NoPositionsHint()
 	}
 
 	tour := previousNoMixData.tour
@@ -385,13 +385,13 @@ func (l *NoMixConstraint) EstimateIsViolated(
 		if previousStopImp.IsPlanned() {
 			previousNoMixData = previousStopImp.ConstraintData(l).(*noMixSolutionStopData)
 			if previousNoMixData.tour != tour || previousNoMixData.content.Name != contentName {
-				return true, constNoPositionsHint
+				return true, NoPositionsHint()
 			}
 		}
 		insertMixItem, hasInsertMixItem = l.insert[moveImpl.stopPositions[idx].Stop().ModelStop()]
 		if hasInsertMixItem {
 			if contentName != insertMixItem.Name {
-				return true, constNoPositionsHint
+				return true, NoPositionsHint()
 			}
 			deltaQuantity += insertMixItem.Quantity
 			continue
@@ -399,10 +399,10 @@ func (l *NoMixConstraint) EstimateIsViolated(
 		removeMixItem, hasRemoveMixItem := l.remove[moveImpl.stopPositions[idx].Stop().ModelStop()]
 		if hasRemoveMixItem {
 			if contentName != removeMixItem.Name || contentQuantity+deltaQuantity < removeMixItem.Quantity {
-				return true, constNoPositionsHint
+				return true, NoPositionsHint()
 			}
 			deltaQuantity -= removeMixItem.Quantity
 		}
 	}
-	return false, constNoPositionsHint
+	return false, NoPositionsHint()
 }

--- a/model_constraint_successors.go
+++ b/model_constraint_successors.go
@@ -77,10 +77,10 @@ func (l *SuccessorConstraint) EstimateIsViolated(
 		stop := stopPosition.Stop().ModelStop()
 		nextModelStop := stopPosition.Next().ModelStop()
 		if disallowed := model.disallowedSuccessors[stop.Index()][nextModelStop.Index()]; disallowed {
-			return true, noPositionsHint()
+			return true, NoPositionsHint()
 		}
 	}
-	return false, noPositionsHint()
+	return false, NoPositionsHint()
 }
 
 // DoesStopHaveViolations returns true if the stop has violations of the

--- a/model_latest.go
+++ b/model_latest.go
@@ -204,7 +204,7 @@ func (l *latest) EstimateIsViolated(
 		move.(*solutionMoveStopsImpl),
 		true,
 	)
-	return score != 0.0, hint.(*stopPositionHintImpl)
+	return score != 0.0, hint
 }
 
 // EstimateDeltaValue estimates the change in value for the given move.
@@ -269,7 +269,7 @@ func (l *latest) estimateDeltaScore(
 		}
 
 		if asConstraint {
-			return 1.0, constNoPositionsHint
+			return 1.0, NoPositionsHint()
 		}
 
 		factor := l.latenessFactor.Value(nil, nil, modelStop)
@@ -289,7 +289,7 @@ func (l *latest) estimateDeltaScore(
 		deltaScore -= currentScore
 	}
 
-	return deltaScore, constNoPositionsHint
+	return deltaScore, NoPositionsHint()
 }
 
 func (l *latest) DoesStopHaveViolations(s SolutionStop) bool {

--- a/model_maximum.go
+++ b/model_maximum.go
@@ -192,13 +192,13 @@ func (l *Maximum) EstimateIsViolated(
 	moveImpl := move.(*solutionMoveStopsImpl)
 
 	if l.hasNoEffect[moveImpl.planUnit.modelPlanStopsUnit.Index()] {
-		return false, constNoPositionsHint
+		return false, NoPositionsHint()
 	}
 
 	// All contributions to the level are negative, no need to check
 	// it will always be below the implied minimum level of zero.
 	if l.hasNegativeValues && !l.hasPositiveValues {
-		return true, constSkipVehiclePositionsHint
+		return true, SkipVehiclePositionsHint()
 	}
 
 	vehicle := moveImpl.vehicle()
@@ -211,9 +211,9 @@ func (l *Maximum) EstimateIsViolated(
 	if l.hasConstantExpression {
 		value := expression.Value(nil, nil, nil)
 		if value > maximum || value < 0 {
-			return true, constSkipVehiclePositionsHint
+			return true, SkipVehiclePositionsHint()
 		}
-		return false, constNoPositionsHint
+		return false, NoPositionsHint()
 	}
 
 	// All contributions to the level are positive, it is sufficient to check
@@ -224,10 +224,10 @@ func (l *Maximum) EstimateIsViolated(
 		cumulativeValue := vehicle.Last().CumulativeValue(expression)
 
 		if cumulativeValue+l.deltas[moveImpl.planUnit.modelPlanStopsUnit.Index()] > maximum {
-			return true, constSkipVehiclePositionsHint
+			return true, SkipVehiclePositionsHint()
 		}
 
-		return false, constNoPositionsHint
+		return false, NoPositionsHint()
 	}
 
 	generator := newSolutionStopGenerator(*moveImpl, false, false)
@@ -246,7 +246,7 @@ func (l *Maximum) EstimateIsViolated(
 		)
 
 		if level > maximum || level < 0 {
-			return true, constNoPositionsHint
+			return true, NoPositionsHint()
 		}
 		previousStop = solutionStop
 		previousModelStop = modelStop
@@ -255,7 +255,7 @@ func (l *Maximum) EstimateIsViolated(
 	if !l.hasNegativeValues {
 		violated := level-previousStop.CumulativeValue(l.Expression())+
 			vehicle.Last().CumulativeValue(l.Expression()) > maximum
-		return violated, constNoPositionsHint
+		return violated, NoPositionsHint()
 	}
 
 	stop, _ := moveImpl.next()
@@ -268,14 +268,14 @@ func (l *Maximum) EstimateIsViolated(
 
 			if level > maximum || level < 0 {
 				// TODO we can hint the move has to be past this stop
-				return true, constNoPositionsHint
+				return true, NoPositionsHint()
 			}
 
 			stop = stop.Next()
 		}
 	}
 
-	return false, constNoPositionsHint
+	return false, NoPositionsHint()
 }
 
 type maximumObjectiveDate struct {

--- a/solution.go
+++ b/solution.go
@@ -438,10 +438,6 @@ func (s *Solution) addInitialSolution(model *Model) error {
 
 				isViolated, hint := constraint.EstimateIsViolated(move)
 
-				if hint == nil {
-					return newErrorOnNilHint(constraint)
-				}
-
 				s.Model().OnEstimatedIsViolated(move, constraint, isViolated, hint)
 
 				if isViolated {
@@ -874,17 +870,7 @@ func (s *Solution) checkConstraintsAndEstimateDeltaScore(
 			constraint,
 		)
 
-		var isViolated bool
-		var hint *stopPositionHintImpl
-
-		isViolatedTemp, hintTemp := constraint.EstimateIsViolated(m)
-
-		if hintTemp == nil {
-			panic(newErrorOnNilHint(constraint))
-		}
-
-		hint = hintTemp.(*stopPositionHintImpl)
-		isViolated = isViolatedTemp
+		isViolated, hint := constraint.EstimateIsViolated(m)
 
 		s.model.OnEstimatedIsViolated(
 			m,
@@ -907,32 +893,19 @@ func (s *Solution) checkConstraintsAndEstimateDeltaScore(
 
 	return objectiveEstimate,
 		true,
-		constNoPositionsHint
+		NoPositionsHint()
 }
-
-var constNoPositionsHintImpl = noPositionsHint()
 
 func (s *Solution) checkConstraints(
 	m SolutionMoveStops,
-) (feasible bool, planPositionsHint *stopPositionHintImpl) {
+) (feasible bool, planPositionsHint StopPositionsHint) {
 	model := s.model
 	for _, constraint := range model.constraints {
 		s.model.OnEstimateIsViolated(
 			constraint,
 		)
 
-		var isViolated bool
-		var hint *stopPositionHintImpl
-
-		isViolatedTemp, hintTemp := constraint.EstimateIsViolated(m)
-
-		if hintTemp == nil {
-			panic(newErrorOnNilHint(constraint))
-		}
-
-		hint = hintTemp.(*stopPositionHintImpl)
-
-		isViolated = isViolatedTemp
+		isViolated, hint := constraint.EstimateIsViolated(m)
 
 		s.model.OnEstimatedIsViolated(
 			m,
@@ -946,7 +919,7 @@ func (s *Solution) checkConstraints(
 		}
 	}
 
-	return true, constNoPositionsHintImpl
+	return true, NoPositionsHint()
 }
 
 func (s *Solution) estimateDeltaScore(

--- a/solution_position_hint.go
+++ b/solution_position_hint.go
@@ -2,103 +2,41 @@
 
 package nextroute
 
-import (
-	"fmt"
-	"reflect"
-	"sync"
-)
-
-var (
-	noHint          *stopPositionHintImpl
-	skipVehicleHint *stopPositionHintImpl
-)
-
-var (
-	onceNoHint          sync.Once
-	onceSkipVehicleHint sync.Once
-)
-
-// The following two variables can be used to avoid allocations.
-var (
-	constSkipVehiclePositionsHint = SkipVehiclePositionsHint()
-	constNoPositionsHint          = NoPositionsHint()
-)
-
 // StopPositionsHint is an interface that can be used to give a hint to the
 // solver about the next stop position. This can be used to speed up the
 // solver. The solver will use the hint if it is available. Hints are generated
 // by the estimate function of a constraint.
-type StopPositionsHint interface {
-	// HasNextStopPositions returns true if the hint contains next positions.
-	HasNextStopPositions() bool
-
-	// NextStopPositions returns the next positions.
-	NextStopPositions() StopPositions
-
-	// SkipVehicle returns true if the solver should skip the vehicle. The
-	// solver will use the hint if it is available.
-	SkipVehicle() bool
+type StopPositionsHint struct {
+	skipVehicle bool
 }
 
 // NoPositionsHint returns a new StopPositionsHint that does not skip
 // the vehicle and does not contain a next stop. The solver will try to find
 // the next stop.
 func NoPositionsHint() StopPositionsHint {
-	return noPositionsHint()
-}
-
-func noPositionsHint() *stopPositionHintImpl {
-	onceNoHint.Do(func() {
-		noHint = &stopPositionHintImpl{
-			skipVehicle: false,
-		}
-	})
-	return noHint
+	return StopPositionsHint{}
 }
 
 // SkipVehiclePositionsHint returns a new StopPositionsHint that skips the
 // vehicle.
 func SkipVehiclePositionsHint() StopPositionsHint {
-	return skipVehiclePositionsHint()
+	return StopPositionsHint{
+		skipVehicle: true,
+	}
 }
 
-func skipVehiclePositionsHint() *stopPositionHintImpl {
-	onceSkipVehicleHint.Do(func() {
-		skipVehicleHint = &stopPositionHintImpl{
-			skipVehicle: true,
-		}
-	})
-	return skipVehicleHint
-}
-
-type stopPositionHintImpl struct {
-	skipVehicle bool
-}
-
-func (n *stopPositionHintImpl) HasNextStopPositions() bool {
+// HasNextStopPositions returns true if the hint contains next positions.
+func (n StopPositionsHint) HasNextStopPositions() bool {
 	return false
 }
 
-func (n *stopPositionHintImpl) NextStopPositions() StopPositions {
+// NextStopPositions returns the next positions.
+func (n StopPositionsHint) NextStopPositions() StopPositions {
 	return StopPositions{}
 }
 
-func (n *stopPositionHintImpl) SkipVehicle() bool {
+// SkipVehicle returns true if the solver should skip the vehicle. The
+// solver will use the hint if it is available.
+func (n StopPositionsHint) SkipVehicle() bool {
 	return n.skipVehicle
-}
-
-func newErrorOnNilHint(constraint ModelConstraint) error {
-	name := reflect.TypeOf(constraint).Name()
-	stringer, ok := constraint.(fmt.Stringer)
-	if ok {
-		name = stringer.String()
-	}
-	identifier, ok := constraint.(Identifier)
-	if ok {
-		name = identifier.ID()
-	}
-	return fmt.Errorf(
-		"constraint %v returned nil hint in EstimateIsViolated, nil is not allowed use NoPositionsHint()",
-		name,
-	)
 }


### PR DESCRIPTION
This PR simplifies stop position hints. It is now a very simple struct that can be inlined. It still offers many ways in the future to model new hints.