### PR TITLE
Remove interface for the plan unit collection

### DIFF
--- a/.github/workflows/go-test-lint.yml
+++ b/.github/workflows/go-test-lint.yml
@@ -2,7 +2,7 @@ name: go
 on: [push]
 
 env:
-  GO_VERSION: 1.22.0
+  GO_VERSION: 1.25.1
 
 jobs:
   # Job for running go linter

--- a/model_objective_unplanned.go
+++ b/model_objective_unplanned.go
@@ -79,7 +79,7 @@ func (t *unplannedObjectiveImpl) EstimateDeltaValue(move SolutionMoveStops) floa
 func (t *unplannedObjectiveImpl) Value(solution *Solution) float64 {
 	unplannedScore := 0.0
 
-	units := solution.UnPlannedPlanUnits().(*solutionPlanUnitCollectionBaseImpl).solutionPlanUnits
+	units := solution.UnPlannedPlanUnits().solutionPlanUnits
 	for _, upu := range units {
 		switch upu := upu.(type) {
 		case *solutionPlanStopsUnitImpl:

--- a/solution.go
+++ b/solution.go
@@ -31,10 +31,10 @@ type Solution struct {
 	// TODO: explore if stopToPlanUnit should rather contain interfaces
 	stopToPlanUnit       []*solutionPlanStopsUnitImpl
 	random               *rand.Rand
-	plannedPlanUnits     solutionPlanUnitCollectionBaseImpl
-	fixedPlanUnits       solutionPlanUnitCollectionBaseImpl
-	unPlannedPlanUnits   solutionPlanUnitCollectionBaseImpl
-	propositionPlanUnits solutionPlanUnitCollectionBaseImpl
+	plannedPlanUnits     *SolutionPlanUnitCollection
+	fixedPlanUnits       *SolutionPlanUnitCollection
+	unPlannedPlanUnits   *SolutionPlanUnitCollection
+	propositionPlanUnits *SolutionPlanUnitCollection
 	vehicleIndices       []int
 
 	vehicles                 []SolutionVehicle
@@ -115,19 +115,19 @@ func NewSolution(
 		constraintSolutionData:   make(map[ModelConstraint]Copier),
 		objectiveSolutionData:    make(map[ModelObjective]Copier),
 		random:                   random,
-		fixedPlanUnits: newSolutionPlanUnitCollectionBaseImpl(
+		fixedPlanUnits: allocateNewSolutionPlanUnitCollection(
 			random,
 			len(model.planUnits),
 		),
-		plannedPlanUnits: newSolutionPlanUnitCollectionBaseImpl(
+		plannedPlanUnits: allocateNewSolutionPlanUnitCollection(
 			random,
 			len(model.planUnits),
 		),
-		unPlannedPlanUnits: newSolutionPlanUnitCollectionBaseImpl(
+		unPlannedPlanUnits: allocateNewSolutionPlanUnitCollection(
 			random,
 			len(model.planUnits),
 		),
-		propositionPlanUnits: newSolutionPlanUnitCollectionBaseImpl(
+		propositionPlanUnits: allocateNewSolutionPlanUnitCollection(
 			random,
 			len(model.planUnits),
 		),
@@ -662,16 +662,16 @@ func (s *Solution) Copy() *Solution {
 		values:                   make([][]float64, len(s.values)),
 		vehicleIndices:           vehicleIndices,
 		random:                   random,
-		fixedPlanUnits: newSolutionPlanUnitCollectionBaseImpl(
+		fixedPlanUnits: allocateNewSolutionPlanUnitCollection(
 			random, s.fixedPlanUnits.Size(),
 		),
-		plannedPlanUnits: newSolutionPlanUnitCollectionBaseImpl(
+		plannedPlanUnits: allocateNewSolutionPlanUnitCollection(
 			random, s.plannedPlanUnits.Size(),
 		),
-		unPlannedPlanUnits: newSolutionPlanUnitCollectionBaseImpl(
+		unPlannedPlanUnits: allocateNewSolutionPlanUnitCollection(
 			random, s.unPlannedPlanUnits.Size(),
 		),
-		propositionPlanUnits: newSolutionPlanUnitCollectionBaseImpl(
+		propositionPlanUnits: allocateNewSolutionPlanUnitCollection(
 			random, s.propositionPlanUnits.Size(),
 		),
 		scores: make(map[ModelObjective]float64, len(s.scores)),
@@ -995,20 +995,20 @@ func (s *Solution) Score() float64 {
 // Fixed plan units are plan units that are not allowed to be planned or
 // unplanned. The union of fixed, planned and unplanned plan units
 // is the set of all plan units in the model.
-func (s *Solution) FixedPlanUnits() ImmutableSolutionPlanUnitCollection {
-	return &s.fixedPlanUnits
+func (s *Solution) FixedPlanUnits() *SolutionPlanUnitCollection {
+	return s.fixedPlanUnits
 }
 
 // PlannedPlanUnits returns the solution plan units that are planned as
 // a collection of solution plan units.
-func (s *Solution) PlannedPlanUnits() ImmutableSolutionPlanUnitCollection {
-	return &s.plannedPlanUnits
+func (s *Solution) PlannedPlanUnits() *SolutionPlanUnitCollection {
+	return s.plannedPlanUnits
 }
 
 // UnPlannedPlanUnits returns the solution plan units that are not
 // planned.
-func (s *Solution) UnPlannedPlanUnits() ImmutableSolutionPlanUnitCollection {
-	return &s.unPlannedPlanUnits
+func (s *Solution) UnPlannedPlanUnits() *SolutionPlanUnitCollection {
+	return s.unPlannedPlanUnits
 }
 
 // PreAllocatedMoveContainer is used to reduce allocations.

--- a/solution_plan_unit_collection.go
+++ b/solution_plan_unit_collection.go
@@ -9,62 +9,22 @@ import (
 	"github.com/nextmv-io/nextroute/common"
 )
 
-// ImmutableSolutionPlanUnitCollection is a collection of solution plan
-// units.
-type ImmutableSolutionPlanUnitCollection interface {
-	// Iterator returns a channel that can be used to iterate over the solution
-	// plan units in the collection.
-	// If you break out of the for loop before the channel is closed,
-	// the goroutine launched by the Iterator() method will be blocked forever,
-	// waiting to send the next element on the channel. This can lead to a
-	// goroutine leak and potentially exhaust the system resources. Therefore,
-	// it is recommended to always use the following pattern:
-	//    iter := collection.Iterator()
-	//    for {
-	//        element, ok := <-iter
-	//        if !ok {
-	//            break
-	//        }
-	//        // do something with element, potentially break out of the loop
-	//    }
-	//    close(iter)
-	Iterator(quit <-chan struct{}) <-chan SolutionPlanUnit
-	// RandomDraw returns a random sample of n different solution plan units.
-	RandomDraw(n int) SolutionPlanUnits
-	// RandomElement returns a random solution plan unit.
-	RandomElement() SolutionPlanUnit
-	// Size return the number of solution plan units in the collection.
-	Size() int
-	// SolutionPlanUnit returns the solution plan units in the collection
-	// which correspond to the given model plan unit. If no such solution
-	// plan unit is found, nil is returned.
-	SolutionPlanUnit(modelPlanUnit ModelPlanUnit) SolutionPlanUnit
-	// SolutionPlanUnits returns the solution plan units in the collection.
-	// The returned slice is a defensive copy of the internal slice, so
-	// modifying it will not affect the collection.
-	SolutionPlanUnits() SolutionPlanUnits
-}
-
 // SolutionPlanUnitCollection is a collection of solution plan units.
-type SolutionPlanUnitCollection interface {
-	ImmutableSolutionPlanUnitCollection
-	// Add adds a [SolutionPlanUnit] to the collection.
-	Add(solutionPlanUnit SolutionPlanUnit)
-	// Remove removes a [SolutionPlanUnit] from the collection.
-	Remove(solutionPlanUnit SolutionPlanUnit)
+type SolutionPlanUnitCollection struct {
+	random            *rand.Rand
+	indices           map[int]int
+	solutionPlanUnits SolutionPlanUnits
 }
 
 // NewSolutionPlanUnitCollection returns a new SolutionPlanUnitCollection.
 func NewSolutionPlanUnitCollection(
 	random *rand.Rand,
 	planUnits SolutionPlanUnits,
-) SolutionPlanUnitCollection {
-	p := solutionPlanUnitCollectionImpl{
-		solutionPlanUnitCollectionBaseImpl: solutionPlanUnitCollectionBaseImpl{
-			random:            random,
-			solutionPlanUnits: slices.Clone(planUnits),
-			indices:           make(map[int]int, len(planUnits)), // TODO: can this be an int slice?
-		},
+) *SolutionPlanUnitCollection {
+	p := SolutionPlanUnitCollection{
+		random:            random,
+		solutionPlanUnits: slices.Clone(planUnits),
+		indices:           make(map[int]int, len(planUnits)), // TODO: can this be an int slice?
 	}
 	for i, planUnit := range planUnits {
 		p.indices[planUnit.ModelPlanUnit().Index()] = i
@@ -72,52 +32,50 @@ func NewSolutionPlanUnitCollection(
 	return &p
 }
 
-type solutionPlanUnitCollectionImpl struct {
-	solutionPlanUnitCollectionBaseImpl
-}
-
-func (s *solutionPlanUnitCollectionImpl) Add(solutionPlanUnit SolutionPlanUnit) {
-	s.add(solutionPlanUnit)
-}
-
-func (s *solutionPlanUnitCollectionImpl) Remove(solutionPlanUnit SolutionPlanUnit) {
-	s.remove(solutionPlanUnit)
-}
-
-func newSolutionPlanUnitCollectionBaseImpl(
+func allocateNewSolutionPlanUnitCollection(
 	random *rand.Rand,
 	initialCapacity int,
-) solutionPlanUnitCollectionBaseImpl {
-	return solutionPlanUnitCollectionBaseImpl{
+) *SolutionPlanUnitCollection {
+	return &SolutionPlanUnitCollection{
 		random:            random,
 		solutionPlanUnits: make(SolutionPlanUnits, 0, initialCapacity),
 		indices:           make(map[int]int, initialCapacity),
 	}
 }
 
-type solutionPlanUnitCollectionBaseImpl struct {
-	random            *rand.Rand
-	indices           map[int]int
-	solutionPlanUnits SolutionPlanUnits
+// Remove removes a [SolutionPlanUnit] from the collection.
+func (p *SolutionPlanUnitCollection) Remove(solutionPlanUnit SolutionPlanUnit) {
+	p.remove(solutionPlanUnit)
 }
 
-func (p *solutionPlanUnitCollectionBaseImpl) SolutionPlanUnits() SolutionPlanUnits {
+// Add adds a [SolutionPlanUnit] to the collection.
+func (p *SolutionPlanUnitCollection) Add(solutionPlanUnit SolutionPlanUnit) {
+	p.add(solutionPlanUnit)
+}
+
+// SolutionPlanUnits returns the solution plan units in the collection.
+// The returned slice is a defensive copy of the internal slice, so
+// modifying it will not affect the collection.
+func (p *SolutionPlanUnitCollection) SolutionPlanUnits() SolutionPlanUnits {
 	return slices.Clone(p.solutionPlanUnits)
 }
 
-func (p *solutionPlanUnitCollectionBaseImpl) RandomElement() SolutionPlanUnit {
+// RandomElement returns a random solution plan unit.
+func (p *SolutionPlanUnitCollection) RandomElement() SolutionPlanUnit {
 	return common.RandomElement(p.random, p.solutionPlanUnits)
 }
 
-func (p *solutionPlanUnitCollectionBaseImpl) Size() int {
+// Size return the number of solution plan units in the collection.
+func (p *SolutionPlanUnitCollection) Size() int {
 	return len(p.solutionPlanUnits)
 }
 
-func (p *solutionPlanUnitCollectionBaseImpl) RandomDraw(n int) SolutionPlanUnits {
+// RandomDraw returns a random sample of n different solution plan units.
+func (p *SolutionPlanUnitCollection) RandomDraw(n int) SolutionPlanUnits {
 	return common.RandomElements(p.random, p.solutionPlanUnits, n)
 }
 
-func (p *solutionPlanUnitCollectionBaseImpl) add(solutionPlanUnit SolutionPlanUnit) {
+func (p *SolutionPlanUnitCollection) add(solutionPlanUnit SolutionPlanUnit) {
 	if _, ok := p.indices[solutionPlanUnit.ModelPlanUnit().Index()]; ok {
 		return
 	}
@@ -125,7 +83,7 @@ func (p *solutionPlanUnitCollectionBaseImpl) add(solutionPlanUnit SolutionPlanUn
 	p.solutionPlanUnits = append(p.solutionPlanUnits, solutionPlanUnit)
 }
 
-func (p *solutionPlanUnitCollectionBaseImpl) remove(solutionPlanUnit SolutionPlanUnit) {
+func (p *SolutionPlanUnitCollection) remove(solutionPlanUnit SolutionPlanUnit) {
 	index, ok := p.indices[solutionPlanUnit.ModelPlanUnit().Index()]
 	if !ok {
 		return
@@ -139,7 +97,24 @@ func (p *solutionPlanUnitCollectionBaseImpl) remove(solutionPlanUnit SolutionPla
 	p.solutionPlanUnits = p.solutionPlanUnits[:lastIndex]
 }
 
-func (p *solutionPlanUnitCollectionBaseImpl) Iterator(quit <-chan struct{}) <-chan SolutionPlanUnit {
+// Iterator returns a channel that can be used to iterate over the solution
+// plan units in the collection.
+// If you break out of the for loop before the channel is closed,
+// the goroutine launched by the Iterator() method will be blocked forever,
+// waiting to send the next element on the channel. This can lead to a
+// goroutine leak and potentially exhaust the system resources. Therefore,
+// it is recommended to always use the following pattern:
+//
+//	iter := collection.Iterator()
+//	for {
+//	    element, ok := <-iter
+//	    if !ok {
+//	        break
+//	    }
+//	    // do something with element, potentially break out of the loop
+//	}
+//	close(iter)
+func (p *SolutionPlanUnitCollection) Iterator(quit <-chan struct{}) <-chan SolutionPlanUnit {
 	ch := make(chan SolutionPlanUnit)
 	go func() {
 		defer close(ch)
@@ -154,7 +129,10 @@ func (p *solutionPlanUnitCollectionBaseImpl) Iterator(quit <-chan struct{}) <-ch
 	return ch
 }
 
-func (p *solutionPlanUnitCollectionBaseImpl) SolutionPlanUnit(
+// SolutionPlanUnit returns the solution plan units in the collection
+// which correspond to the given model plan unit. If no such solution
+// plan unit is found, nil is returned.
+func (p *SolutionPlanUnitCollection) SolutionPlanUnit(
 	modelPlanUnit ModelPlanUnit,
 ) SolutionPlanUnit {
 	if index, ok := p.indices[modelPlanUnit.Index()]; ok {


### PR DESCRIPTION
This simplifies the plan unit collection allowing for better inlining by the compiler (among other things)