### PR TITLE
Update go in github actions to 1.25

### DIFF
--- a/.github/workflows/auto-benchmark.yml
+++ b/.github/workflows/auto-benchmark.yml
@@ -5,7 +5,7 @@ on:
       - "**"
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.25
   PYTHON_VERSION: 3.12
 
 jobs:

--- a/.github/workflows/go-test-lint.yml
+++ b/.github/workflows/go-test-lint.yml
@@ -2,7 +2,7 @@ name: go
 on: [push]
 
 env:
-  GO_VERSION: 1.22.0
+  GO_VERSION: 1.25.1
 
 jobs:
   # Job for running go linter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
         type: boolean
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.25
   PYTHON_VERSION: 3.12
 
 jobs:


### PR DESCRIPTION
This updates the GH actions to go 1.25. It also results in a small performance boost.