### PR TITLE
Moves to macos-15-intel for deprecated macos-13 runner

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -20,7 +20,7 @@ jobs:
             ubuntu-24.04-arm,
             windows-latest,
             macos-latest,
-            macos-13,
+            macos-15-intel,
           ]
     steps:
       - name: git clone

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
             platform: linux-amd64
           - image: ubuntu-24.04-arm
             platform: linux-arm64
-          - image: macos-13
+          - image: macos-15-intel
             platform: macos-amd64
           - image: macos-14
             platform: macos-arm64


### PR DESCRIPTION
# Description

Moves the workflows to the newer `macos-15-intel` runner to get away from the deprecated `macos-13` runner. This is our runner for testing on darwin x64.

## Changes

- Move workflows to `macos-15-intel` (replacing `macos-13`).

Resolves ENG-6627