### PR TITLE
Perf/smaller move

### DIFF
--- a/solution_move_stops.go
+++ b/solution_move_stops.go
@@ -5,6 +5,7 @@ package nextroute
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/nextmv-io/nextroute/common"
 )
@@ -82,7 +83,7 @@ func newNotExecutableSolutionMoveStops(planUnit *solutionPlanStopsUnitImpl) *sol
 	return &solutionMoveStopsImpl{
 		planUnit:  planUnit,
 		valueSeen: 1,
-		allowed:   false,
+		value:     math.NaN(),
 	}
 }
 
@@ -91,15 +92,20 @@ type solutionMoveStopsImpl struct {
 	stopPositions []StopPosition
 	valueSeen     int
 	value         float64
-	allowed       bool
+}
+
+func moveValueIfAllowed(value float64, allowed bool) float64 {
+	if !allowed {
+		return math.NaN()
+	}
+	return value
 }
 
 // reset resets the move to its initial state.
 // We assume the planUnit stays the same.
 func (m *solutionMoveStopsImpl) reset() {
 	m.stopPositions = m.stopPositions[:0]
-	m.allowed = false
-	m.value = 0.0
+	m.value = math.NaN()
 	m.valueSeen = 1
 }
 
@@ -109,7 +115,6 @@ func (m *solutionMoveStopsImpl) replaceBy(newStop *solutionMoveStopsImpl, newVal
 	m.reset()
 	m.value = newStop.value
 	m.valueSeen = newValueSeen
-	m.allowed = newStop.allowed
 	m.stopPositions = append(m.stopPositions, newStop.stopPositions...)
 }
 
@@ -120,7 +125,7 @@ func (m *solutionMoveStopsImpl) String() string {
 		m.stopPositions,
 		m.valueSeen,
 		m.value,
-		m.allowed,
+		m.isAllowed(),
 	)
 }
 
@@ -286,8 +291,12 @@ func (m *solutionMoveStopsImpl) StopPositionsLength() int {
 func (m *solutionMoveStopsImpl) IsExecutable() bool {
 	return m.stopPositions != nil &&
 		!m.planUnit.IsPlanned() &&
-		m.allowed &&
+		m.isAllowed() &&
 		!m.planUnit.IsFixed()
+}
+
+func (m *solutionMoveStopsImpl) isAllowed() bool {
+	return !math.IsNaN(m.value)
 }
 
 func (m *solutionMoveStopsImpl) IsImprovement() bool {
@@ -626,12 +635,10 @@ func newMoveStops(
 		stopPositions: stopPositionsImpl,
 		value:         0.0,
 		valueSeen:     0,
-		allowed:       true,
 	}
 	if checkConstraintsAndEstimateDeltaScore {
 		value, allowed, _ := planUnit.(*solutionPlanStopsUnitImpl).Solution().checkConstraintsAndEstimateDeltaScore(move)
-		move.value = value
-		move.allowed = allowed
+		move.value = moveValueIfAllowed(value, allowed)
 		move.valueSeen = 1
 	}
 	return move, nil

--- a/solution_move_stops_generator.go
+++ b/solution_move_stops_generator.go
@@ -106,7 +106,7 @@ func SolutionMoveStopsGenerator(
 	m := preAllocatedMoveContainer.singleStopPosSolutionMoveStop
 	m.(*solutionMoveStopsImpl).reset()
 	m.(*solutionMoveStopsImpl).planUnit = planUnit
-	m.(*solutionMoveStopsImpl).allowed = false
+	m.(*solutionMoveStopsImpl).value = moveValueIfAllowed(0.0, false)
 	if len(source) == 0 {
 		yield(m)
 		return
@@ -129,7 +129,7 @@ func SolutionMoveStopsGenerator(
 			m.(*solutionMoveStopsImpl).reset()
 			m.(*solutionMoveStopsImpl).planUnit = planUnit
 			m.(*solutionMoveStopsImpl).stopPositions = positions
-			m.(*solutionMoveStopsImpl).allowed = false
+			m.(*solutionMoveStopsImpl).value = moveValueIfAllowed(0.0, false)
 			m.(*solutionMoveStopsImpl).valueSeen = 1
 			yield(m)
 		}, shouldStop)
@@ -148,7 +148,7 @@ func SolutionMoveStopsGenerator(
 			m.(*solutionMoveStopsImpl).reset()
 			m.(*solutionMoveStopsImpl).planUnit = planUnit
 			m.(*solutionMoveStopsImpl).stopPositions = positions
-			m.(*solutionMoveStopsImpl).allowed = false
+			m.(*solutionMoveStopsImpl).value = moveValueIfAllowed(0.0, false)
 			m.(*solutionMoveStopsImpl).valueSeen = 1
 			yield(m)
 		}, shouldStop)

--- a/solution_plan_stops_unit.go
+++ b/solution_plan_stops_unit.go
@@ -195,7 +195,6 @@ func (p *solutionPlanStopsUnitImpl) unplan() (bool, error) {
 	move.planUnit = p
 	move.value = 0.0
 	move.valueSeen = 0
-	move.allowed = true
 	for _, solutionStop := range p.solutionStops {
 		move.stopPositions = append(move.stopPositions, newStopPosition(
 			solutionStop.Previous(),

--- a/solution_vehicle.go
+++ b/solution_vehicle.go
@@ -47,8 +47,7 @@ func (v SolutionVehicle) firstMovePlanStopsUnit(
 				stop = true
 				return
 			}
-			nextMove.(*solutionMoveStopsImpl).value = value
-			nextMove.(*solutionMoveStopsImpl).allowed = allowed
+			nextMove.(*solutionMoveStopsImpl).value = moveValueIfAllowed(value, allowed)
 			nextMove.(*solutionMoveStopsImpl).valueSeen = nextMove.ValueSeen()
 			if nextMove.IsExecutable() {
 				bestMove = takeBestInPlace(bestMove, nextMove)
@@ -231,7 +230,7 @@ func (v SolutionVehicle) bestMovePlanSingleStop(
 	}
 	if len(moves) == 0 {
 		returnToMoveContainerPool(movesPtr)
-		move.(*solutionMoveStopsImpl).allowed = false
+		move.(*solutionMoveStopsImpl).value = moveValueIfAllowed(0.0, false)
 		return move
 	}
 	// we got the best move here in O(n)
@@ -242,7 +241,6 @@ func (v SolutionVehicle) bestMovePlanSingleStop(
 		move,
 	)
 	if allowed {
-		move.(*solutionMoveStopsImpl).allowed = true
 		returnToMoveContainerPool(movesPtr)
 		return move
 	}
@@ -266,13 +264,12 @@ func (v SolutionVehicle) bestMovePlanSingleStop(
 			move,
 		)
 		if allowed {
-			move.(*solutionMoveStopsImpl).allowed = true
 			returnToMoveContainerPool(movesPtr)
 			return move
 		}
 	}
 	returnToMoveContainerPool(movesPtr)
-	move.(*solutionMoveStopsImpl).allowed = false
+	move.(*solutionMoveStopsImpl).value = moveValueIfAllowed(0.0, false)
 	return move
 }
 
@@ -293,8 +290,7 @@ func (v SolutionVehicle) bestMoveSequence(
 				stop = true
 				return
 			}
-			nextMove.(*solutionMoveStopsImpl).value = value
-			nextMove.(*solutionMoveStopsImpl).allowed = allowed
+			nextMove.(*solutionMoveStopsImpl).value = moveValueIfAllowed(value, allowed)
 			nextMove.(*solutionMoveStopsImpl).valueSeen = nextMove.ValueSeen()
 			if allowed {
 				bestMove = takeBestInPlace(bestMove, nextMove)


### PR DESCRIPTION
Just a small experiment to reduce the size of the move struct by encoding a disallowed move as `nan` in the value field, this saves 8 bytes.