### PR TITLE
Fixes tuple example for capacities objective

### DIFF
--- a/factory/model.go
+++ b/factory/model.go
@@ -28,7 +28,7 @@ type Options struct {
 		} `json:"enable"`
 	} `json:"constraints"`
 	Objectives struct {
-		Capacities               string  `json:"capacities" usage:"capacity objective, provide triple for each resource 'name:default;factor:1.0;offset,0.0'" default:""`
+		Capacities               string  `json:"capacities" usage:"capacity objective, provide triple for each resource 'name=default;factor=1.0;offset=0.0'" default:""`
 		MinStops                 float64 `json:"min_stops" usage:"factor to weigh the min stops objective" default:"1.0"`
 		EarlyArrivalPenalty      float64 `json:"early_arrival_penalty" usage:"factor to weigh the early arrival objective" default:"1.0"`
 		LateArrivalPenalty       float64 `json:"late_arrival_penalty" usage:"factor to weigh the late arrival objective" default:"1.0"`

--- a/factory/model.go
+++ b/factory/model.go
@@ -28,7 +28,7 @@ type Options struct {
 		} `json:"enable"`
 	} `json:"constraints"`
 	Objectives struct {
-		Capacities               string  `json:"capacities" usage:"capacity objective, provide triple for each resource 'name:default;factor:1.0;offset;0.0'" default:""`
+		Capacities               string  `json:"capacities" usage:"capacity objective, provide triple for each resource 'name:default;factor:1.0;offset,0.0'" default:""`
 		MinStops                 float64 `json:"min_stops" usage:"factor to weigh the min stops objective" default:"1.0"`
 		EarlyArrivalPenalty      float64 `json:"early_arrival_penalty" usage:"factor to weigh the early arrival objective" default:"1.0"`
 		LateArrivalPenalty       float64 `json:"late_arrival_penalty" usage:"factor to weigh the late arrival objective" default:"1.0"`

--- a/src/nextroute/options.py
+++ b/src/nextroute/options.py
@@ -81,7 +81,7 @@ class Options(BaseModel):
     MODEL_OBJECTIVES_CAPACITIES: str = ""
     """
     Capacity objective, provide triple for each resource
-    `name:default;factor:1.0;offset;0.0`.
+    `name:default;factor:1.0;offset,0.0`.
     """
     MODEL_OBJECTIVES_CLUSTER: float = 0.0
     """Factor to weigh the cluster objective."""

--- a/src/nextroute/options.py
+++ b/src/nextroute/options.py
@@ -81,7 +81,7 @@ class Options(BaseModel):
     MODEL_OBJECTIVES_CAPACITIES: str = ""
     """
     Capacity objective, provide triple for each resource
-    `name:default;factor:1.0;offset,0.0`.
+    `name=default;factor=1.0;offset=0.0`.
     """
     MODEL_OBJECTIVES_CLUSTER: float = 0.0
     """Factor to weigh the cluster objective."""


### PR DESCRIPTION
# Description

Fixes the tuple example for the capacities objective. The syntax was incorrect.

## Changes

- Fixes the tuple example for the capacities objective option.