### PR TITLE
Fixes stops of stop groups getting lost during unplanning

### DIFF
--- a/solve_operator_unplan.go
+++ b/solve_operator_unplan.go
@@ -168,6 +168,12 @@ func (d *solveOperatorUnPlanImpl) unplanOneIsland(
 	numberOfStops int,
 ) (int, error) {
 	planUnit := solution.PlannedPlanUnits().RandomElement()
+
+	// Reject island unplanning if it's a units-unit.
+	if isUnitsUnit(planUnit) {
+		return 0, nil
+	}
+
 	planStopsUnit := common.RandomElement(solution.Random(), planUnit.PlannedPlanStopsUnits())
 	for _, solutionStop := range planStopsUnit.(*solutionPlanStopsUnitImpl).solutionStops {
 		return d.unplanOneStopIsland(
@@ -222,10 +228,23 @@ func (d *solveOperatorUnPlanImpl) unplanSomeStopsOfOneVehicle(
 
 	for _, stop := range stops {
 		if stop.IsPlanned() && !stop.IsFixed() {
+			// TODO: should this be inverted (our chance is 0.2, so 80% chance
+			// to unplan - a.k.a. NOT skip unplanning)?
 			if solution.Random().Float64() < chance {
 				continue
 			}
-			unplanned, err := stop.PlanStopsUnit().UnPlan()
+
+			planStopsUnit := stop.PlanStopsUnit()
+
+			// // Get parent of unit to unplan full units.
+			// planStopsUnit := solution.PlannedPlanUnits().SolutionPlanUnit(stop.modelStop().planUnit)
+
+			// Reject unplanning if it's a units-unit.
+			if isUnitsUnit(planStopsUnit) {
+				continue
+			}
+
+			unplanned, err := planStopsUnit.UnPlan()
 			if err != nil {
 				return 0, err
 			}

--- a/solve_operator_unplan.go
+++ b/solve_operator_unplan.go
@@ -290,3 +290,13 @@ func (d *solveOperatorUnPlanImpl) unplanLocation(
 
 	return count, nil
 }
+
+func isUnitsUnit(plannedPlanUnit SolutionPlanUnit) bool {
+	switch plannedPlanUnit.(type) {
+	case SolutionPlanStopsUnit:
+		return false
+	case SolutionPlanUnitsUnit:
+		return true
+	}
+	panic("unknown solution plan unit type")
+}


### PR DESCRIPTION
# Description

Fixes stop groups bug where stops can get lost from the output altogether. The issues arises when unplanning units units in the vehicle and island heuristics. It is an artifact of how stops and units are connected and handled (particularly, if the change needs to get rolled back).

## Changes

- Fixes stop group bug causing stops to get lost.