### PR TITLE
Fix Distance Limit Constraint Panic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -211,6 +211,9 @@ linters:
           - tagliatelle
         path: schema/input\.go
       - linters:
+          - revive
+        text: avoid meaningless package names
+      - linters:
           - contextcheck
         path: check/format\.go
       - linters:

--- a/model_expression_composed.go
+++ b/model_expression_composed.go
@@ -73,7 +73,7 @@ func (t *composedPerVehicleTypeExpressionImpl) HasNegativeValues() bool {
 		return true
 	}
 	for _, expression := range t.expressions {
-		if expression.HasNegativeValues() {
+		if expression != nil && expression.HasNegativeValues() {
 			return true
 		}
 	}
@@ -85,7 +85,7 @@ func (t *composedPerVehicleTypeExpressionImpl) HasPositiveValues() bool {
 		return true
 	}
 	for _, expression := range t.expressions {
-		if expression.HasPositiveValues() {
+		if expression != nil && expression.HasPositiveValues() {
 			return true
 		}
 	}


### PR DESCRIPTION
# Summary
* Set() grows the internal expressions slice to accommodate the given vehicle type index, which can leave nil slots for skipped indices
* HasNegativeValues() and HasPositiveValues() iterated over the slice without nil-checking, causing a nil pointer dereference panic when non-contiguous vehicle type indices were used (e.g., indices 0 and 2 set, index 1 skipped)
* Added expression != nil && guards in both methods, consistent with the nil-check pattern already used in Get() and Value()
Reproduction
* The panic is triggered in addDistanceLimitConstraint when vehicle types with non-contiguous indices have MaxDistance set - composed.Set() is called only for those vehicle types, leaving gaps in the slice that cause the panic downstream when NewMaximum evaluates the expression.