### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-benchmark.yml
+++ b/.github/workflows/auto-benchmark.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/go-test-lint.yml
+++ b/.github/workflows/go-test-lint.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: set up go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
           version: v2.9.0
   # Job for running tests
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: set up go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: go test (exclude golden file tests from Python package)

--- a/.github/workflows/header.yml
+++ b/.github/workflows/header.yml
@@ -14,10 +14,10 @@ jobs:
         language: ["go", "python"]
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 18.8
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: DavidAnson/markdownlint-cli2-action@v7
         with:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -12,6 +12,6 @@ jobs:
       - name: git clone
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: DavidAnson/markdownlint-cli2-action@v7
+      - uses: DavidAnson/markdownlint-cli2-action@6b51ade7a9e4a75a7ad929842dd298a3804ebe8b  # v23.1.0
         with:
           globs: "**/*.md"

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.13
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,10 +27,10 @@ jobs:
           ]
     steps:
       - name: git clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -49,7 +49,7 @@ jobs:
       # Source:https://github.com/nextmv-io/nextroute/actions/runs/11414952328/job/31764458969?pr=65
       - name: set up Go
         if: ${{ matrix.platform != 'windows-latest' }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
     needs: bump-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.ref_name }}
 
@@ -141,7 +141,7 @@ jobs:
       - name: Check metadata
         run: pipx run twine check dist/*
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-artifacts-sdist
           path: dist/*.tar.gz
@@ -225,7 +225,7 @@ jobs:
       contents: read
       id-token: write # This is required for trusted publishing to PyPI
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           merge-multiple: true
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,12 @@ jobs:
           fi
 
       - name: set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: set up go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -167,29 +167,29 @@ jobs:
 
     steps:
       - name: git clone ${{ github.ref_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.ref_name }}
 
       - name: set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: set up go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Build wheels
         if: matrix.platform != 'macos-arm64'
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
         env:
           MACOSX_DEPLOYMENT_TARGET: 13.0
 
       - name: Build wheels
         if: matrix.platform == 'macos-arm64'
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
         env:
           # TODO: default wheel repair does not recognize the arm64 wheel.
           # This seems like a bug in delocate-wheel, which is the tool used by cibuildwheel,
@@ -203,7 +203,7 @@ jobs:
         shell: bash
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-artifacts-${{ matrix.platform }}
           path: wheelhouse/*.whl
@@ -231,19 +231,19 @@ jobs:
           path: dist
 
       - name: Print directory tree for reference
-        uses: jaywcjlove/github-action-folder-tree@main
+        uses: jaywcjlove/github-action-folder-tree@e0a53e98a23389b0019777ed2eb9e66e88817b2b  # v1.3.0
         with:
           path: ./
 
       - name: Publish package distributions to PyPI
         if: ${{ matrix.target-env == 'pypi' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: ./dist
 
       - name: Publish package distributions to TestPyPI
         if: ${{ matrix.target-env == 'testpypi' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: ./dist


### PR DESCRIPTION
# Description

Pins all workflow actions to their latest version via shas for improved security (avoiding supply chain attacks).

## Changes

- `actions/checkout`: `v4` → `v6.0.2` (`de0fac2e4500...`)
- `actions/setup-go`: `v5` → `v6.4.0` (`4a3601121dd0...`)
- `actions/setup-python`: `v5` → `v6.2.0` (`a309ff8b426b...`)
- `golangci/golangci-lint-action`: `v9` → `v9.2.0` (`1e7e51e771db...`)
- `actions/setup-node`: `v4` → `v6.4.0` (`48b55a011bda...`)
- `pypa/cibuildwheel`: `v2.21.3` → `v3.4.1` (`8d2b08b68458...`)
- `actions/upload-artifact`: `v4` → `v7.0.1` (`043fb46d1a93...`)
- `jaywcjlove/github-action-folder-tree`: `main` → `v1.3.0` (`e0a53e98a233...`)
- `pypa/gh-action-pypi-publish`: `release/v1` → `v1.14.0` (`cef221092ed1...`)
